### PR TITLE
fix: show question instructions

### DIFF
--- a/src/lib/components/QuestionCard.svelte
+++ b/src/lib/components/QuestionCard.svelte
@@ -82,9 +82,11 @@
 			{#if question.is_mandatory}
 				<span class="ml-1 text-red-500">*</span>
 			{/if}
-			<p class="text-muted-foreground mt-2 text-sm">
-				{question.instructions}
-			</p>
+			{#if question.instructions}
+				<span class="text-muted-foreground mt-2 block text-sm">
+					{question.instructions}
+				</span>
+			{/if}
 		</Card.Description>
 	</Card.Header>
 

--- a/src/lib/components/QuestionCard.svelte
+++ b/src/lib/components/QuestionCard.svelte
@@ -77,10 +77,15 @@
 			{serialNumber} <span>OF {totalQuestions}</span>
 			<!-- <span class="text-muted-foreground float-end">{`1 Mark`}</span> -->
 		</Card.Title>
-		<Card.Description class="text-base/normal font-medium"
-			>{question.question_text}{#if question.is_mandatory}<span class="ml-1 text-red-500">*</span>
-			{/if}</Card.Description
-		>
+		<Card.Description class="text-base/normal font-medium">
+			{question.question_text}
+			{#if question.is_mandatory}
+				<span class="ml-1 text-red-500">*</span>
+			{/if}
+			<p class="text-muted-foreground mt-2 text-sm">
+				{question.instructions}
+			</p>
+		</Card.Description>
 	</Card.Header>
 
 	<Card.Content class="p-5 pt-1">


### PR DESCRIPTION
closes: #57 

<img width="224" height="426" alt="image" src="https://github.com/user-attachments/assets/8d6f345e-ff10-4971-ad2e-39d0e6047673" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the layout of question cards by displaying the question text and mandatory asterisk on separate lines.
  * Added a muted, smaller-font paragraph below the question text to show instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->