### PR TITLE
Display candidate marks

### DIFF
--- a/src/lib/components/TestResult.svelte
+++ b/src/lib/components/TestResult.svelte
@@ -45,10 +45,18 @@
 					<Table.Cell class="border-r">Not Attempted</Table.Cell>
 					<Table.Cell>{notAttempted}</Table.Cell>
 				</Table.Row>
-				<Table.Row class="font-semibold">
-					<Table.Cell class="border-r">Total marks obtained</Table.Cell>
-					<Table.Cell>{resultData.correct_answer} / {totalQuestions}</Table.Cell>
-				</Table.Row>
+				{#if resultData.marks_obtained}
+					<Table.Row class="font-semibold">
+						<Table.Cell class="border-r">Marks obtained</Table.Cell>
+						<Table.Cell>{resultData.marks_obtained}</Table.Cell>
+					</Table.Row>
+				{/if}
+				{#if resultData.marks_maximum}
+					<Table.Row class="font-semibold">
+						<Table.Cell class="border-r">Total marks</Table.Cell>
+						<Table.Cell>{resultData.marks_maximum}</Table.Cell>
+					</Table.Row>
+				{/if}
 			</Table.Body>
 		</Table.Root>
 	{/if}

--- a/src/lib/components/TestResult.svelte
+++ b/src/lib/components/TestResult.svelte
@@ -45,16 +45,10 @@
 					<Table.Cell class="border-r">Not Attempted</Table.Cell>
 					<Table.Cell>{notAttempted}</Table.Cell>
 				</Table.Row>
-				{#if resultData.marks_obtained}
+				{#if resultData.marks_obtained !== null && resultData.marks_maximum !== null}
 					<Table.Row class="font-semibold">
-						<Table.Cell class="border-r">Marks obtained</Table.Cell>
-						<Table.Cell>{resultData.marks_obtained}</Table.Cell>
-					</Table.Row>
-				{/if}
-				{#if resultData.marks_maximum}
-					<Table.Row class="font-semibold">
-						<Table.Cell class="border-r">Total marks</Table.Cell>
-						<Table.Cell>{resultData.marks_maximum}</Table.Cell>
+						<Table.Cell class="border-r">Total marks obtained</Table.Cell>
+						<Table.Cell>{resultData.marks_obtained} / {resultData.marks_maximum}</Table.Cell>
 					</Table.Row>
 				{/if}
 			</Table.Body>


### PR DESCRIPTION
closes: #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Changes**
  * Removed the always-visible "Total marks obtained" row from test results.
  * Added a conditional "Marks obtained / Total marks" row that appears only when both values are present.
  * Adjusted labels/layout to show separate marks values; other result figures (correct/incorrect/not attempted) and calculations remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->