### PR TITLE
Hiding Total marks on landing page

### DIFF
--- a/src/lib/components/LandingPage.svelte
+++ b/src/lib/components/LandingPage.svelte
@@ -14,10 +14,6 @@
 	const testOverview = [
 		{ label: 'Total questions', value: `${testDetails.total_questions} questions` },
 		{
-			label: 'Total marks',
-			value: `${testDetails.marks ? testDetails.marks + ' marks' : 'N/A'}`
-		},
-		{
 			label: 'Total duration',
 			value: `${testDetails.time_limit ? testDetails.time_limit + ' minutes' : 'N/A'}`
 		},


### PR DESCRIPTION
Hiding Display of Total Marks on landing page as the API is not configured to display the requried total marks yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Test Overview on the landing page: removed the “Total marks” field.
  * The section now shows only: Total questions, Total duration, and Questions per page.
  * Users will no longer see a computed marks value in this area; all other details and behavior remain unchanged.
  * Applies to all tests displayed on the landing page; no other sections or interactions were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->