### PR TITLE
allow rendering of urls in completion message

### DIFF
--- a/src/lib/components/TestResult.svelte
+++ b/src/lib/components/TestResult.svelte
@@ -15,9 +15,9 @@
 		{testDetails.name}
 	</h6>
 	<h3 class="mb-1 text-lg font-semibold">Submitted Successfully</h3>
-	<p class="text-sm/normal">
+	<p class="text-sm/normal [&_a]:text-blue-600 [&_a]:underline hover:[&_a]:text-blue-800">
 		{#if testDetails.completion_message}
-			{testDetails.completion_message}
+			{@html testDetails.completion_message}
 		{:else}
 			Congrats on completing the test! {#if resultData}
 				You have attempted {attempted} questions.


### PR DESCRIPTION
One can configure a completion message like below.
```
Test completion message

<a href="your-url" target="_blank" rel="noopener noreferrer">Please provide your feedback</a>
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Test completion messages now support rich text, enabling proper rendering of formatting and clickable links.
- Style
  - Improved link appearance within completion messages: blue text, underlined, with a distinct hover color for better visibility and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->