### PR TITLE
Show Mark or Marks appropriately

### DIFF
--- a/src/lib/components/ViewFeedback.svelte
+++ b/src/lib/components/ViewFeedback.svelte
@@ -69,9 +69,9 @@
 						{idx + 1} <span>{$t('OF')} {feedbackWithQuestions.length}</span>
 
 						{#if item.question?.marking_scheme}
+							{@const mark = item.question.marking_scheme.correct}
 							<span class="text-muted-foreground float-end">
-								{item.question.marking_scheme.correct}
-								{$t('Marks')}
+								{mark === 1 ? `1 ${$t('Mark')}` : `${mark} ${$t('Marks')}`}
 							</span>
 						{/if}
 					</Card.Title>

--- a/src/lib/components/ViewFeedback.svelte.test.ts
+++ b/src/lib/components/ViewFeedback.svelte.test.ts
@@ -51,7 +51,7 @@ describe('ViewFeedback', () => {
 				props: { feedback, testQuestions: mockTestQuestionsResponse }
 			});
 
-			expect(screen.getAllByText(/\d+ Marks/)).toHaveLength(3);
+			expect(screen.getAllByText(/\d+ Marks?/)).toHaveLength(3);
 		});
 
 		it('should display question instructions when present', () => {


### PR DESCRIPTION
fixes : #155 
Replaced hardcoded "Marks" labels with proper singular/plural logic:

1 → "1 Mark"

>1 → "N Marks"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined marking scheme display with proper grammatical pluralization: now shows "1 Mark" for single marks and "X Marks" for multiple marks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->