### PR TITLE
Conditionally display marking scheme based on show_marks

### DIFF
--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -153,6 +153,7 @@
 									bind:selectedQuestions
 									showFeedback={testDetails?.show_feedback_immediately ?? false}
 									showMarkForReview={testDetails?.bookmark ?? true}
+									showMarks={testDetails?.show_marks ?? true}
 								/>
 							</div>
 						{/each}

--- a/src/lib/components/Question.svelte.test.ts
+++ b/src/lib/components/Question.svelte.test.ts
@@ -173,6 +173,60 @@ describe('Question', () => {
 			});
 		});
 	});
+
+	describe('show_marks in testDetails', () => {
+		it('should display marks when testDetails.show_marks is true', async () => {
+			render(Question, {
+				props: {
+					candidate: mockCandidate,
+					testQuestions,
+					testDetails: { ...testDetails, show_marks: true }
+				}
+			});
+
+			await vi.waitFor(() => {
+				expect(screen.getByText(mockQuestions[0].question_text)).toBeInTheDocument();
+			});
+
+			expect(screen.getAllByText(/\d+ Marks?/).length).toBeGreaterThan(0);
+		});
+
+		it('should hide marks when testDetails.show_marks is false', async () => {
+			render(Question, {
+				props: {
+					candidate: mockCandidate,
+					testQuestions,
+					testDetails: { ...testDetails, show_marks: false }
+				}
+			});
+
+			await vi.waitFor(() => {
+				expect(screen.getByText(mockQuestions[0].question_text)).toBeInTheDocument();
+			});
+
+			expect(screen.queryAllByText(/\d+ Marks?/)).toHaveLength(0);
+		});
+
+		it('should display marks by default when testDetails.show_marks is undefined', async () => {
+			const testDetailsWithoutShowMarks = testDetails as typeof testDetails & {
+				show_marks?: boolean;
+			};
+
+			render(Question, {
+				props: {
+					candidate: mockCandidate,
+					testQuestions,
+					testDetails: testDetailsWithoutShowMarks
+				}
+			});
+
+			await vi.waitFor(() => {
+				expect(screen.getByText(mockQuestions[0].question_text)).toBeInTheDocument();
+			});
+
+			expect(screen.getAllByText(/\d+ Marks?/).length).toBeGreaterThan(0);
+		});
+	});
 });
 
 describe('Support for Localization', () => {

--- a/src/lib/components/QuestionCard.svelte
+++ b/src/lib/components/QuestionCard.svelte
@@ -33,7 +33,8 @@
 		totalQuestions,
 		selectedQuestions = $bindable(),
 		showFeedback = false,
-		showMarkForReview = true
+		showMarkForReview = true,
+		showMarks = true
 	}: {
 		question: TQuestion;
 		candidate: TCandidate;
@@ -42,6 +43,7 @@
 		selectedQuestions: TSelection[];
 		showFeedback?: boolean;
 		showMarkForReview?: boolean;
+		showMarks?: boolean;
 	} = $props();
 
 	const options = question.options;
@@ -556,7 +558,7 @@
 	<Card.Header class="p-5">
 		<Card.Title class="mb-5 border-b pb-3 text-sm">
 			{serialNumber} <span>{$t('OF')} {totalQuestions}</span>
-			{#if question?.marking_scheme}
+			{#if showMarks && question?.marking_scheme}
 				{@const mark = question.marking_scheme.correct}
 				{@const scheme = question.marking_scheme}
 				<span class="group relative float-end cursor-help select-none">

--- a/src/lib/components/QuestionCard.svelte.test.ts
+++ b/src/lib/components/QuestionCard.svelte.test.ts
@@ -523,6 +523,68 @@ describe('QuestionCard', () => {
 		});
 	});
 
+	describe('showMarks prop', () => {
+		const defaultProps = {
+			serialNumber: 1,
+			candidate: mockCandidate,
+			totalQuestions: 10,
+			selectedQuestions: []
+		};
+
+		it('should show marks by default when showMarks prop is not provided', () => {
+			render(QuestionCard, {
+				props: { question: mockSingleChoiceQuestion, ...defaultProps }
+			});
+
+			expect(screen.getByText('1 Mark')).toBeInTheDocument();
+		});
+
+		it('should show marks when showMarks is true', () => {
+			render(QuestionCard, {
+				props: { question: mockSingleChoiceQuestion, ...defaultProps, showMarks: true }
+			});
+
+			expect(screen.getByText('1 Mark')).toBeInTheDocument();
+		});
+
+		it('should hide marks when showMarks is false', () => {
+			render(QuestionCard, {
+				props: { question: mockSingleChoiceQuestion, ...defaultProps, showMarks: false }
+			});
+
+			expect(screen.queryByText('1 Mark')).not.toBeInTheDocument();
+		});
+
+		it('should hide marking scheme tooltip when showMarks is false', () => {
+			render(QuestionCard, {
+				props: { question: mockSingleChoiceQuestion, ...defaultProps, showMarks: false }
+			});
+
+			expect(screen.queryByText('Marking Scheme')).not.toBeInTheDocument();
+		});
+
+		it('should not affect other card elements when showMarks is false', () => {
+			render(QuestionCard, {
+				props: { question: mockSingleChoiceQuestion, ...defaultProps, showMarks: false }
+			});
+
+			expect(screen.getByText(mockSingleChoiceQuestion.question_text)).toBeInTheDocument();
+			mockSingleChoiceQuestion.options.forEach((option) => {
+				expect(
+					screen.getByText(new RegExp(`${option.key}\\. ${option.value}`))
+				).toBeInTheDocument();
+			});
+		});
+
+		it('should hide plural marks when showMarks is false', () => {
+			render(QuestionCard, {
+				props: { question: mockMultipleChoiceQuestion, ...defaultProps, showMarks: false }
+			});
+
+			expect(screen.queryByText('2 Marks')).not.toBeInTheDocument();
+		});
+	});
+
 	describe('Subjective question functionality', () => {
 		it('should render textarea for subjective questions', () => {
 			render(QuestionCard, {


### PR DESCRIPTION
fixes : #183 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to control whether question marks and marking-scheme info are shown; configurable at the test level and shown by default.
* **Tests**
  * Added tests covering show/hide behavior for marks and marking-scheme display, including default, true, and false cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->