### PR TITLE
Make phone validation more restrictive

### DIFF
--- a/src/lib/components/form/validation.test.ts
+++ b/src/lib/components/form/validation.test.ts
@@ -109,29 +109,33 @@ describe('validateField', () => {
 	});
 
 	describe('phone validation', () => {
-		it('should pass for valid phone with special characters', () => {
-			const field = createField({ field_type: 'phone' });
-			expect(validateField(field, '+1-234-567-8901')).toBeNull();
-		});
-
-		it('should pass for simple numeric phone', () => {
+		it('should pass for exactly 10 digits', () => {
 			const field = createField({ field_type: 'phone' });
 			expect(validateField(field, '1234567890')).toBeNull();
 		});
 
+		it('should fail for phone with formatting characters', () => {
+			const field = createField({ field_type: 'phone' });
+			expect(validateField(field, '+1-234-567-8901')).toBe(
+				'Please enter a valid 10-digit phone number'
+			);
+		});
+
 		it('should fail for phone with letters', () => {
 			const field = createField({ field_type: 'phone' });
-			expect(validateField(field, '123-abc-7890')).toBe('Please enter a valid phone number');
+			expect(validateField(field, '123abc7890')).toBe('Please enter a valid 10-digit phone number');
 		});
 
-		it('should fail for phone too short', () => {
+		it('should fail for phone shorter than 10 digits', () => {
 			const field = createField({ field_type: 'phone' });
-			expect(validateField(field, '12345')).toBe('Please enter a valid phone number');
+			expect(validateField(field, '123456789')).toBe('Please enter a valid 10-digit phone number');
 		});
 
-		it('should fail for phone too long', () => {
+		it('should fail for phone longer than 10 digits', () => {
 			const field = createField({ field_type: 'phone' });
-			expect(validateField(field, '1'.repeat(21))).toBe('Please enter a valid phone number');
+			expect(validateField(field, '12345678901')).toBe(
+				'Please enter a valid 10-digit phone number'
+			);
 		});
 
 		it('should return custom error for invalid phone', () => {
@@ -144,7 +148,9 @@ describe('validateField', () => {
 
 		it('should validate phone even without validation object', () => {
 			const field = createField({ field_type: 'phone' });
-			expect(validateField(field, 'not-a-phone!!')).toBe('Please enter a valid phone number');
+			expect(validateField(field, 'not-a-phone!!')).toBe(
+				'Please enter a valid 10-digit phone number'
+			);
 		});
 	});
 

--- a/src/lib/components/form/validation.ts
+++ b/src/lib/components/form/validation.ts
@@ -30,9 +30,9 @@ export function validateField(field: TFormField, value: unknown): string | null 
 	}
 
 	if (field.field_type === 'phone') {
-		const phoneRegex = /^[0-9+\-\s()]{7,20}$/;
+		const phoneRegex = /^\d{10}$/;
 		if (!phoneRegex.test(stringValue)) {
-			return field.validation?.custom_error_message || 'Please enter a valid phone number';
+			return field.validation?.custom_error_message || 'Please enter a valid 10-digit phone number';
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/sashakt-platform/sashakt-webapp/issues/220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened phone number validation to require exactly 10 digits in numeric format. Previously, formatting characters were accepted; now only numeric input is validated. Error messages have been updated to provide clearer guidance about the 10-digit requirement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sashakt-platform/sashakt-webapp/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->