### PR TITLE
Tracking Time of a Single Question

### DIFF
--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -25,6 +25,7 @@
 
 	let { candidate, testQuestions, testDetails = null } = $props();
 	let isSubmittingTest = $state(false);
+	let questionCardRef = $state<{ flushTime: () => void } | undefined>();
 
 	// for controlling confirmation dialog display
 	let submitDialogOpen = $state(false);
@@ -173,6 +174,13 @@
 		return () => localStorage.removeItem(`sashakt-session-${candidate.candidate_test_id}`);
 	});
 
+	$effect(() => {
+		if (perPage !== 1) return;
+		const handler = () => questionCardRef?.flushTime?.();
+		window.addEventListener('sashakt-time-up', handler);
+		return () => window.removeEventListener('sashakt-time-up', handler);
+	});
+
 	// scroll to top and update current question index when page changes
 	function handlePageChange(newPage: number) {
 		currentQuestionIndex = (newPage - 1) * perPage;
@@ -289,6 +297,7 @@
 									showMarkForReview={testDetails.bookmark}
 									showMarks={testDetails?.show_marks ?? true}
 									trackTime={perPage === 1}
+									bind:this={questionCardRef}
 								/>
 							</div>
 						{/each}
@@ -389,7 +398,8 @@
 													method="POST"
 													use:enhance={handleSubmitTestEnhance}
 												>
-													<Button type="submit" disabled={isSubmittingTest} class="w-full">
+													<Button type="submit" disabled={isSubmittingTest} class="w-full"
+														onclick={() => questionCardRef?.flushTime?.()}>
 														{#if isSubmittingTest}
 															<Spinner />
 														{/if}

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -171,7 +171,10 @@
 	$effect(() => {
 		// clear the localStorage on un-mount of the component, which takes place
 		// only if the test is submitted successfully
-		return () => localStorage.removeItem(`sashakt-session-${candidate.candidate_test_id}`);
+		return () => {
+			localStorage.removeItem(`sashakt-session-${candidate.candidate_test_id}`);
+			localStorage.removeItem(`sashakt-timer-${candidate.candidate_test_id}`);
+		};
 	});
 
 	$effect(() => {
@@ -297,6 +300,7 @@
 									showMarkForReview={testDetails.bookmark}
 									showMarks={testDetails?.show_marks ?? true}
 									trackTime={perPage === 1}
+									pauseTimerWhenInactive={testDetails?.pause_timer_when_inactive ?? false}
 									bind:this={questionCardRef}
 								/>
 							</div>

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -288,6 +288,7 @@
 									showFeedback={testDetails.show_feedback_immediately}
 									showMarkForReview={testDetails.bookmark}
 									showMarks={testDetails?.show_marks ?? true}
+									trackTime={perPage === 1}
 								/>
 							</div>
 						{/each}

--- a/src/lib/components/QuestionCard.svelte
+++ b/src/lib/components/QuestionCard.svelte
@@ -124,6 +124,65 @@
 		}
 	};
 
+	export function flushTime() {
+		if (!trackTime) return;
+
+		const timerKey = `sashakt-timer-${candidate.candidate_test_id}`;
+		const current = sessionStorage.getItem(timerKey);
+		sessionStorage.removeItem(timerKey);
+
+		if (!current) return;
+
+		const { questionId, questionType, startTime } = JSON.parse(current);
+		const elapsed = Math.round((Date.now() - startTime) / 1000);
+		if (elapsed <= 0) return;
+
+		const existing = selectedQuestions.find((q) => q.question_revision_id === questionId);
+		const previousState = JSON.parse(JSON.stringify(selectedQuestions));
+
+		let updatedTime: number;
+		let submitResponse: number[] | string | null;
+		let submitBookmarked: boolean;
+		let submitIsReviewed: boolean;
+
+		if (existing) {
+			updatedTime = existing.time_spent + elapsed;
+			submitResponse = existing.response;
+			submitBookmarked = existing.bookmarked;
+			submitIsReviewed = existing.is_reviewed ?? false;
+			selectedQuestions = selectedQuestions.map((q) =>
+				q.question_revision_id === questionId ? { ...q, time_spent: updatedTime } : q
+			);
+		} else {
+			updatedTime = elapsed;
+			submitResponse = null;
+			submitBookmarked = false;
+			submitIsReviewed = false;
+			const defaultResponse = questionType === question_type_enum.SUBJECTIVE ? '' : [];
+			selectedQuestions = [
+				...selectedQuestions,
+				{
+					question_revision_id: questionId,
+					response: defaultResponse,
+					visited: true,
+					time_spent: updatedTime,
+					bookmarked: false,
+					is_reviewed: false
+				}
+			];
+		}
+		updateStore();
+
+		(async () => {
+			try {
+				await submitAnswer(questionId, submitResponse, submitBookmarked, submitIsReviewed, updatedTime);
+			} catch {
+				selectedQuestions = previousState;
+				updateStore();
+			}
+		})();
+	}
+
 	$effect(() => {
 		if (!trackTime) return;
 
@@ -135,66 +194,10 @@
 		const storedData = stored ? JSON.parse(stored) : null;
 		const startTime = storedData?.questionId === questionId ? storedData.startTime : Date.now();
 
-		sessionStorage.setItem(timerKey, JSON.stringify({ questionId, startTime }));
+		sessionStorage.setItem(timerKey, JSON.stringify({ questionId, questionType, startTime }));
 
 		return () => {
-			sessionStorage.removeItem(timerKey);
-			const elapsed = Math.round((Date.now() - startTime) / 1000);
-			if (elapsed <= 0) return;
-
-			const existing = selectedQuestions.find((q) => q.question_revision_id === questionId);
-			const previousState = JSON.parse(JSON.stringify(selectedQuestions));
-
-			let updatedTime: number;
-			let submitResponse: number[] | string | null;
-			let submitBookmarked: boolean;
-			let submitIsReviewed: boolean;
-
-			if (existing) {
-				updatedTime = existing.time_spent + elapsed;
-				submitResponse = existing.response;
-				submitBookmarked = existing.bookmarked;
-				submitIsReviewed = existing.is_reviewed ?? false;
-				selectedQuestions = selectedQuestions.map((q) =>
-					q.question_revision_id === questionId ? { ...q, time_spent: updatedTime } : q
-				);
-			} else {
-				updatedTime = elapsed;
-				submitResponse = null;
-				submitBookmarked = false;
-				submitIsReviewed = false;
-				const defaultResponse = questionType === question_type_enum.SUBJECTIVE ? '' : [];
-				selectedQuestions = [
-					...selectedQuestions,
-					{
-						question_revision_id: questionId,
-						response: defaultResponse,
-						visited: true,
-						time_spent: updatedTime,
-						bookmarked: false,
-						is_reviewed: false
-					}
-				];
-			}
-			updateStore();
-			isSubmitting = true;
-
-			(async () => {
-				try {
-					await submitAnswer(
-						questionId,
-						submitResponse,
-						submitBookmarked,
-						submitIsReviewed,
-						updatedTime
-					);
-				} catch {
-					selectedQuestions = previousState;
-					updateStore();
-				} finally {
-					isSubmitting = false;
-				}
-			})();
+			flushTime();
 		};
 	});
 

--- a/src/lib/components/QuestionCard.svelte
+++ b/src/lib/components/QuestionCard.svelte
@@ -38,7 +38,8 @@
 		showFeedback = false,
 		showMarkForReview = true,
 		showMarks = true,
-		trackTime = false
+		trackTime = false,
+		pauseTimerWhenInactive = false
 	}: {
 		question: TQuestion;
 		candidate: TCandidate;
@@ -49,6 +50,7 @@
 		showMarkForReview?: boolean;
 		showMarks?: boolean;
 		trackTime?: boolean;
+		pauseTimerWhenInactive?: boolean;
 	} = $props();
 
 	// key to force remount of RadioGroup on error, this is to prevent radio button from being checked
@@ -130,13 +132,14 @@
 		if (!trackTime) return;
 
 		const timerKey = `sashakt-timer-${candidate.candidate_test_id}`;
-		const current = sessionStorage.getItem(timerKey);
-		sessionStorage.removeItem(timerKey);
+		const current = localStorage.getItem(timerKey);
+		localStorage.removeItem(timerKey);
 
 		if (!current) return;
 
-		const { questionId, questionType, startTime } = JSON.parse(current);
-		const elapsed = Math.round((Date.now() - startTime) / 1000);
+		const { questionId, questionType, startTime, accumulated } = JSON.parse(current);
+		const activePeriod = startTime !== null ? Date.now() - startTime : 0;
+		const elapsed = Math.round(((accumulated ?? 0) + activePeriod) / 1000);
 		if (elapsed <= 0) return;
 
 		const existing = selectedQuestions.find((q) => q.question_revision_id === questionId);
@@ -192,13 +195,54 @@
 		const questionType = question.question_type;
 		const timerKey = `sashakt-timer-${candidate.candidate_test_id}`;
 
-		const stored = sessionStorage.getItem(timerKey);
+		const stored = localStorage.getItem(timerKey);
 		const storedData = stored ? JSON.parse(stored) : null;
-		const startTime = storedData?.questionId === questionId ? storedData.startTime : Date.now();
+		const sameQuestion = storedData?.questionId === questionId;
 
-		sessionStorage.setItem(timerKey, JSON.stringify({ questionId, questionType, startTime }));
+		// Restore accumulated time from before tab close, but always start a fresh startTime.
+		// Never restore the old startTime — that would count the gap while the tab was closed.
+		const accumulated = sameQuestion ? (storedData.accumulated ?? 0) : 0;
+		const startTime = Date.now();
+
+		localStorage.setItem(timerKey, JSON.stringify({ questionId, questionType, startTime, accumulated }));
+
+		// Synchronously bank elapsed into accumulated and null out startTime.
+		// Used on tab hide (pauseTimerWhenInactive) and always on pagehide (tab close).
+		const bankTime = () => {
+			const current = localStorage.getItem(timerKey);
+			if (!current) return;
+			const data = JSON.parse(current);
+			if (data.startTime !== null) {
+				data.accumulated = (data.accumulated ?? 0) + (Date.now() - data.startTime);
+				data.startTime = null;
+				localStorage.setItem(timerKey, JSON.stringify(data));
+			}
+		};
+
+		const onVisibilityChange = () => {
+			if (!pauseTimerWhenInactive) return;
+			if (document.hidden) {
+				bankTime();
+			} else {
+				const current = localStorage.getItem(timerKey);
+				if (!current) return;
+				const data = JSON.parse(current);
+				if (data.startTime === null) {
+					data.startTime = Date.now();
+					localStorage.setItem(timerKey, JSON.stringify(data));
+				}
+			}
+		};
+
+		// pagehide fires just before the tab closes — bank time so it survives in localStorage.
+		const onPageHide = () => bankTime();
+
+		document.addEventListener('visibilitychange', onVisibilityChange);
+		window.addEventListener('pagehide', onPageHide);
 
 		return () => {
+			document.removeEventListener('visibilitychange', onVisibilityChange);
+			window.removeEventListener('pagehide', onPageHide);
 			flushTime();
 		};
 	});

--- a/src/lib/components/QuestionCard.svelte
+++ b/src/lib/components/QuestionCard.svelte
@@ -100,6 +100,8 @@
 	};
 
 	const confirmViewFeedback = async () => {
+		flushTime();
+
 		const answeredQuestion = selectedQuestion(question.id);
 		const currentResponse = answeredQuestion?.response ?? [];
 		const currentBookmarked = answeredQuestion?.bookmarked ?? false;
@@ -184,7 +186,7 @@
 	}
 
 	$effect(() => {
-		if (!trackTime) return;
+		if (!trackTime || isFeedbackViewed) return;
 
 		const questionId = question.id;
 		const questionType = question.question_type;

--- a/src/lib/components/QuestionCard.svelte
+++ b/src/lib/components/QuestionCard.svelte
@@ -207,7 +207,7 @@
 			candidate,
 			bookmarked,
 			is_reviewed,
-			time_spent: time_spent ?? 0
+			...(time_spent !== undefined ? { time_spent } : {})
 		};
 
 		try {

--- a/src/lib/components/QuestionCard.svelte
+++ b/src/lib/components/QuestionCard.svelte
@@ -37,7 +37,8 @@
 		selectedQuestions = $bindable(),
 		showFeedback = false,
 		showMarkForReview = true,
-		showMarks = true
+		showMarks = true,
+		trackTime = false
 	}: {
 		question: TQuestion;
 		candidate: TCandidate;
@@ -47,6 +48,7 @@
 		showFeedback?: boolean;
 		showMarkForReview?: boolean;
 		showMarks?: boolean;
+		trackTime?: boolean;
 	} = $props();
 
 	// key to force remount of RadioGroup on error, this is to prevent radio button from being checked
@@ -123,6 +125,8 @@
 	};
 
 	$effect(() => {
+		if (!trackTime) return;
+
 		const questionId = question.id;
 		const questionType = question.question_type;
 		const timerKey = `sashakt-timer-${candidate.candidate_test_id}`;

--- a/src/lib/components/QuestionCard.svelte
+++ b/src/lib/components/QuestionCard.svelte
@@ -122,18 +122,92 @@
 		}
 	};
 
+	$effect(() => {
+		const questionId = question.id;
+		const questionType = question.question_type;
+		const timerKey = `sashakt-timer-${candidate.candidate_test_id}`;
+
+		const stored = sessionStorage.getItem(timerKey);
+		const storedData = stored ? JSON.parse(stored) : null;
+		const startTime = storedData?.questionId === questionId ? storedData.startTime : Date.now();
+
+		sessionStorage.setItem(timerKey, JSON.stringify({ questionId, startTime }));
+
+		return () => {
+			sessionStorage.removeItem(timerKey);
+			const elapsed = Math.round((Date.now() - startTime) / 1000);
+			if (elapsed <= 0) return;
+
+			const existing = selectedQuestions.find((q) => q.question_revision_id === questionId);
+			const previousState = JSON.parse(JSON.stringify(selectedQuestions));
+
+			let updatedTime: number;
+			let submitResponse: number[] | string | null;
+			let submitBookmarked: boolean;
+			let submitIsReviewed: boolean;
+
+			if (existing) {
+				updatedTime = existing.time_spent + elapsed;
+				submitResponse = existing.response;
+				submitBookmarked = existing.bookmarked;
+				submitIsReviewed = existing.is_reviewed ?? false;
+				selectedQuestions = selectedQuestions.map((q) =>
+					q.question_revision_id === questionId ? { ...q, time_spent: updatedTime } : q
+				);
+			} else {
+				updatedTime = elapsed;
+				submitResponse = null;
+				submitBookmarked = false;
+				submitIsReviewed = false;
+				const defaultResponse = questionType === question_type_enum.SUBJECTIVE ? '' : [];
+				selectedQuestions = [
+					...selectedQuestions,
+					{
+						question_revision_id: questionId,
+						response: defaultResponse,
+						visited: true,
+						time_spent: updatedTime,
+						bookmarked: false,
+						is_reviewed: false
+					}
+				];
+			}
+			updateStore();
+			isSubmitting = true;
+
+			(async () => {
+				try {
+					await submitAnswer(
+						questionId,
+						submitResponse,
+						submitBookmarked,
+						submitIsReviewed,
+						updatedTime
+					);
+				} catch {
+					selectedQuestions = previousState;
+					updateStore();
+				} finally {
+					isSubmitting = false;
+				}
+			})();
+		};
+	});
+
 	const submitAnswer = async (
 		questionId: number,
 		response: number[] | string | null,
 		bookmarked?: boolean,
-		is_reviewed?: boolean
+		is_reviewed?: boolean,
+		time_spent?: number
 	) => {
 		const data = {
 			question_revision_id: questionId,
 			response: response == null ? null : response.length > 0 ? response : null,
 			candidate,
 			bookmarked,
-			is_reviewed
+			is_reviewed,
+			time_spent: time_spent ?? 0
 		};
 
 		try {

--- a/src/lib/components/QuestionCard.svelte
+++ b/src/lib/components/QuestionCard.svelte
@@ -144,25 +144,13 @@
 
 		const existing = selectedQuestions.find((q) => q.question_revision_id === questionId);
 		const previousState = JSON.parse(JSON.stringify(selectedQuestions));
-
-		let updatedTime: number;
-		let submitResponse: number[] | string | null;
-		let submitBookmarked: boolean;
-		let submitIsReviewed: boolean;
+		const updatedTime = (existing?.time_spent ?? 0) + elapsed;
 
 		if (existing) {
-			updatedTime = existing.time_spent + elapsed;
-			submitResponse = existing.response;
-			submitBookmarked = existing.bookmarked;
-			submitIsReviewed = existing.is_reviewed ?? false;
 			selectedQuestions = selectedQuestions.map((q) =>
 				q.question_revision_id === questionId ? { ...q, time_spent: updatedTime } : q
 			);
 		} else {
-			updatedTime = elapsed;
-			submitResponse = null;
-			submitBookmarked = false;
-			submitIsReviewed = false;
 			const defaultResponse = questionType === question_type_enum.SUBJECTIVE ? '' : [];
 			selectedQuestions = [
 				...selectedQuestions,
@@ -180,7 +168,7 @@
 
 		(async () => {
 			try {
-				await submitAnswer(questionId, submitResponse, submitBookmarked, submitIsReviewed, updatedTime);
+				await submitAnswer(questionId, undefined, undefined, undefined, updatedTime);
 			} catch {
 				selectedQuestions = previousState;
 				updateStore();
@@ -249,17 +237,21 @@
 
 	const submitAnswer = async (
 		questionId: number,
-		response: number[] | string | null,
+		response?: number[] | string | null,
 		bookmarked?: boolean,
 		is_reviewed?: boolean,
 		time_spent?: number
 	) => {
 		const data = {
 			question_revision_id: questionId,
-			response: response == null ? null : response.length > 0 ? response : null,
 			candidate,
-			bookmarked,
-			is_reviewed,
+			...(response !== undefined
+				? {
+						response: response == null ? null : response.length > 0 ? response : null,
+						...(bookmarked !== undefined ? { bookmarked } : {}),
+						...(is_reviewed !== undefined ? { is_reviewed } : {})
+					}
+				: {}),
 			...(time_spent !== undefined ? { time_spent } : {})
 		};
 

--- a/src/lib/components/QuestionCard.svelte.test.ts
+++ b/src/lib/components/QuestionCard.svelte.test.ts
@@ -3994,3 +3994,353 @@ describe('QuestionCard', () => {
 		});
 	});
 });
+
+describe('Time tracking', () => {
+	const timerKey = `sashakt-timer-${mockCandidate.candidate_test_id}`;
+
+	const baseProps = {
+		question: mockSingleChoiceQuestion,
+		serialNumber: 1,
+		candidate: mockCandidate,
+		totalQuestions: 10,
+		selectedQuestions: [] as TSelection[],
+		trackTime: true,
+		pauseTimerWhenInactive: false
+	};
+
+	// Flush the microtask queue enough for async IIFEs (submitAnswer chain) to resolve
+	const flushMicrotasks = async () => {
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+	};
+
+	const getSubmitCalls = () =>
+		vi.mocked(fetch).mock.calls.filter((c) => String(c[0]).includes('/api/submit-answer'));
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.mocked(fetch).mockResolvedValue(
+			createMockResponse({ success: true }) as unknown as Response
+		);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+	});
+
+	describe('localStorage setup on mount', () => {
+		it('writes timer entry to localStorage when trackTime is true', () => {
+			render(QuestionCard, { props: baseProps });
+
+			const stored = localStorage.getItem(timerKey);
+			expect(stored).not.toBeNull();
+			const data = JSON.parse(stored!);
+			expect(data.questionId).toBe(mockSingleChoiceQuestion.id);
+			expect(data.questionType).toBe(mockSingleChoiceQuestion.question_type);
+			expect(typeof data.startTime).toBe('number');
+			expect(data.accumulated).toBe(0);
+		});
+
+		it('does not write to localStorage when trackTime is false', () => {
+			render(QuestionCard, { props: { ...baseProps, trackTime: false } });
+
+			expect(localStorage.getItem(timerKey)).toBeNull();
+		});
+
+		it('does not write to localStorage when question is already reviewed', () => {
+			render(QuestionCard, {
+				props: {
+					...baseProps,
+					selectedQuestions: [
+						{
+							question_revision_id: mockSingleChoiceQuestion.id,
+							response: [mockSingleChoiceQuestion.options[0].id],
+							visited: true,
+							time_spent: 10,
+							bookmarked: false,
+							is_reviewed: true
+						}
+					]
+				}
+			});
+
+			expect(localStorage.getItem(timerKey)).toBeNull();
+		});
+	});
+
+	describe('flushTime() on unmount', () => {
+		it('sends time_spent to the submit-answer API on unmount', async () => {
+			const { unmount } = render(QuestionCard, { props: baseProps });
+
+			vi.advanceTimersByTime(10000); // 10 seconds
+			unmount();
+			await flushMicrotasks();
+
+			const calls = getSubmitCalls();
+			expect(calls.length).toBeGreaterThan(0);
+			const body = JSON.parse((calls[0][1] as RequestInit).body as string);
+			expect(body.time_spent).toBe(10);
+			expect(body.question_revision_id).toBe(mockSingleChoiceQuestion.id);
+		});
+
+		it('adds elapsed time on top of existing time_spent from selectedQuestions', async () => {
+			const { unmount } = render(QuestionCard, {
+				props: {
+					...baseProps,
+					selectedQuestions: [
+						{
+							question_revision_id: mockSingleChoiceQuestion.id,
+							response: [mockSingleChoiceQuestion.options[0].id],
+							visited: true,
+							time_spent: 20,
+							bookmarked: false,
+							is_reviewed: false
+						}
+					]
+				}
+			});
+
+			vi.advanceTimersByTime(5000); // 5 more seconds on top of existing 20
+			unmount();
+			await flushMicrotasks();
+
+			const calls = getSubmitCalls();
+			const body = JSON.parse((calls[0][1] as RequestInit).body as string);
+			expect(body.time_spent).toBe(25); // 20 prior + 5 new
+		});
+
+		it('removes the localStorage key immediately (prevents double-counting on a second call)', async () => {
+			const { unmount } = render(QuestionCard, { props: baseProps });
+
+			vi.advanceTimersByTime(10000);
+			unmount();
+			await flushMicrotasks();
+
+			// Key removed synchronously inside flushTime() before the async API call
+			expect(localStorage.getItem(timerKey)).toBeNull();
+		});
+
+		it('does not call submit-answer API when elapsed time is 0', async () => {
+			const { unmount } = render(QuestionCard, { props: baseProps });
+
+			// No time advance — elapsed rounds to 0
+			unmount();
+			await flushMicrotasks();
+
+			expect(getSubmitCalls()).toHaveLength(0);
+		});
+
+		it('does not call submit-answer API on unmount when trackTime is false', async () => {
+			const { unmount } = render(QuestionCard, {
+				props: { ...baseProps, trackTime: false }
+			});
+
+			vi.advanceTimersByTime(10000);
+			unmount();
+			await flushMicrotasks();
+
+			expect(getSubmitCalls()).toHaveLength(0);
+		});
+
+		it('sends response: null and time_spent for an unanswered non-subjective question', async () => {
+			const { unmount } = render(QuestionCard, { props: baseProps });
+
+			vi.advanceTimersByTime(7000);
+			unmount();
+			await flushMicrotasks();
+
+			const body = JSON.parse((getSubmitCalls()[0][1] as RequestInit).body as string);
+			expect(body.response).toBeNull();
+			expect(body.time_spent).toBe(7);
+		});
+
+		it('sends response: null and time_spent for a new unanswered subjective question', async () => {
+			const { unmount } = render(QuestionCard, {
+				props: { ...baseProps, question: mockSubjectiveQuestion }
+			});
+
+			vi.advanceTimersByTime(10000);
+			unmount();
+			await flushMicrotasks();
+
+			const body = JSON.parse((getSubmitCalls()[0][1] as RequestInit).body as string);
+			expect(body.question_revision_id).toBe(mockSubjectiveQuestion.id);
+			expect(body.response).toBeNull(); // empty string '' maps to null in submitAnswer
+			expect(body.time_spent).toBe(10);
+		});
+
+		it('does not throw and still calls API even when the API call itself fails', async () => {
+			vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+			const { unmount } = render(QuestionCard, { props: baseProps });
+
+			vi.advanceTimersByTime(10000);
+			expect(() => unmount()).not.toThrow();
+
+			await flushMicrotasks();
+
+			expect(getSubmitCalls().length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('pagehide — tab close banking', () => {
+		it('banks accumulated time and nulls startTime in localStorage on pagehide', () => {
+			render(QuestionCard, { props: baseProps });
+
+			vi.advanceTimersByTime(10000); // 10s
+			window.dispatchEvent(new Event('pagehide'));
+
+			const data = JSON.parse(localStorage.getItem(timerKey)!);
+			expect(data.startTime).toBeNull();
+			expect(data.accumulated).toBeGreaterThanOrEqual(10000);
+		});
+
+		it('restores accumulated time on reopen and excludes the closed-tab gap', async () => {
+			// Simulate state left in localStorage after pagehide fired 10s into the question
+			localStorage.setItem(
+				timerKey,
+				JSON.stringify({
+					questionId: mockSingleChoiceQuestion.id,
+					questionType: mockSingleChoiceQuestion.question_type,
+					startTime: null,
+					accumulated: 10000
+				})
+			);
+
+			// Gap while tab was closed — Date.now() advances but the component is not mounted
+			vi.advanceTimersByTime(60000);
+
+			// Candidate reopens the tab
+			const { unmount } = render(QuestionCard, { props: baseProps });
+			vi.advanceTimersByTime(5000); // 5s after reopen
+			unmount();
+			await flushMicrotasks();
+
+			const body = JSON.parse((getSubmitCalls()[0][1] as RequestInit).body as string);
+			// 10s accumulated + 5s new; 60s gap is excluded because $effect resets startTime on mount
+			expect(body.time_spent).toBe(15);
+		});
+
+		it('does not carry over accumulated time when reopening on a different question', async () => {
+			// Pre-banked time belongs to mockSingleChoiceQuestion (id=1)
+			localStorage.setItem(
+				timerKey,
+				JSON.stringify({
+					questionId: mockSingleChoiceQuestion.id,
+					questionType: mockSingleChoiceQuestion.question_type,
+					startTime: null,
+					accumulated: 30000
+				})
+			);
+
+			// Candidate reopens on a different question
+			const { unmount } = render(QuestionCard, {
+				props: { ...baseProps, question: mockMultipleChoiceQuestion }
+			});
+			vi.advanceTimersByTime(5000);
+			unmount();
+			await flushMicrotasks();
+
+			const body = JSON.parse((getSubmitCalls()[0][1] as RequestInit).body as string);
+			expect(body.question_revision_id).toBe(mockMultipleChoiceQuestion.id);
+			expect(body.time_spent).toBe(5); // no carry-over from the different question's banked time
+		});
+	});
+
+	describe('pauseTimerWhenInactive = true — tab visibility', () => {
+		it('nulls startTime (pauses timer) in localStorage when tab becomes hidden', () => {
+			render(QuestionCard, { props: { ...baseProps, pauseTimerWhenInactive: true } });
+
+			vi.advanceTimersByTime(10000);
+			Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+			document.dispatchEvent(new Event('visibilitychange'));
+
+			const data = JSON.parse(localStorage.getItem(timerKey)!);
+			expect(data.startTime).toBeNull();
+			expect(data.accumulated).toBeGreaterThanOrEqual(10000);
+		});
+
+		it('sets a fresh startTime (resumes timer) when tab becomes visible again', () => {
+			render(QuestionCard, { props: { ...baseProps, pauseTimerWhenInactive: true } });
+
+			// Hide
+			Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+			document.dispatchEvent(new Event('visibilitychange'));
+
+			vi.advanceTimersByTime(30000);
+
+			// Show
+			Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+			document.dispatchEvent(new Event('visibilitychange'));
+
+			const data = JSON.parse(localStorage.getItem(timerKey)!);
+			expect(data.startTime).not.toBeNull(); // timer running again
+		});
+
+		it('excludes hidden time from elapsed: 10s visible + 30s hidden + 5s visible = 15s', async () => {
+			const { unmount } = render(QuestionCard, {
+				props: { ...baseProps, pauseTimerWhenInactive: true }
+			});
+
+			vi.advanceTimersByTime(10000); // 10s visible
+
+			Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+			document.dispatchEvent(new Event('visibilitychange'));
+			vi.advanceTimersByTime(30000); // 30s hidden — should NOT count
+
+			Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+			document.dispatchEvent(new Event('visibilitychange'));
+			vi.advanceTimersByTime(5000); // 5s visible again
+
+			unmount();
+			await flushMicrotasks();
+
+			const body = JSON.parse((getSubmitCalls()[0][1] as RequestInit).body as string);
+			expect(body.time_spent).toBe(15); // 10 + 5, not 45
+		});
+
+		it('counts only accumulated when unmounted while tab is hidden', async () => {
+			const { unmount } = render(QuestionCard, {
+				props: { ...baseProps, pauseTimerWhenInactive: true }
+			});
+
+			vi.advanceTimersByTime(10000); // 10s visible
+
+			Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+			document.dispatchEvent(new Event('visibilitychange'));
+			vi.advanceTimersByTime(30000); // 30s hidden
+
+			unmount(); // flushTime called while tab is still hidden
+			await flushMicrotasks();
+
+			const body = JSON.parse((getSubmitCalls()[0][1] as RequestInit).body as string);
+			expect(body.time_spent).toBe(10); // only the visible accumulated; hidden gap excluded
+		});
+	});
+
+	describe('pauseTimerWhenInactive = false — tab visibility', () => {
+		it('does not pause on tab hide — startTime stays non-null', () => {
+			render(QuestionCard, { props: { ...baseProps, pauseTimerWhenInactive: false } });
+
+			vi.advanceTimersByTime(10000);
+			Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+			document.dispatchEvent(new Event('visibilitychange'));
+
+			const data = JSON.parse(localStorage.getItem(timerKey)!);
+			expect(data.startTime).not.toBeNull(); // timer still running
+		});
+
+		it('pagehide still banks time even when pauseTimerWhenInactive is false', () => {
+			render(QuestionCard, { props: { ...baseProps, pauseTimerWhenInactive: false } });
+
+			vi.advanceTimersByTime(10000);
+			window.dispatchEvent(new Event('pagehide'));
+
+			const data = JSON.parse(localStorage.getItem(timerKey)!);
+			expect(data.startTime).toBeNull();
+			expect(data.accumulated).toBeGreaterThanOrEqual(10000);
+		});
+	});
+});

--- a/src/lib/components/QuestionCard.svelte.test.ts
+++ b/src/lib/components/QuestionCard.svelte.test.ts
@@ -4144,7 +4144,7 @@ describe('Time tracking', () => {
 			expect(getSubmitCalls()).toHaveLength(0);
 		});
 
-		it('sends response: null and time_spent for an unanswered non-subjective question', async () => {
+		it('sends only time_spent (no response) for an unanswered non-subjective question', async () => {
 			const { unmount } = render(QuestionCard, { props: baseProps });
 
 			vi.advanceTimersByTime(7000);
@@ -4152,11 +4152,11 @@ describe('Time tracking', () => {
 			await flushMicrotasks();
 
 			const body = JSON.parse((getSubmitCalls()[0][1] as RequestInit).body as string);
-			expect(body.response).toBeNull();
+			expect(body.response).toBeUndefined();
 			expect(body.time_spent).toBe(7);
 		});
 
-		it('sends response: null and time_spent for a new unanswered subjective question', async () => {
+		it('sends only time_spent (no response) for a new unanswered subjective question', async () => {
 			const { unmount } = render(QuestionCard, {
 				props: { ...baseProps, question: mockSubjectiveQuestion }
 			});
@@ -4167,7 +4167,7 @@ describe('Time tracking', () => {
 
 			const body = JSON.parse((getSubmitCalls()[0][1] as RequestInit).body as string);
 			expect(body.question_revision_id).toBe(mockSubjectiveQuestion.id);
-			expect(body.response).toBeNull(); // empty string '' maps to null in submitAnswer
+			expect(body.response).toBeUndefined();
 			expect(body.time_spent).toBe(10);
 		});
 

--- a/src/lib/components/TestTimer.svelte
+++ b/src/lib/components/TestTimer.svelte
@@ -81,7 +81,9 @@
 					<div class="bg-card px-6 py-6">
 						<Dialog.Description>
 							<p class="text-muted-foreground text-sm">
-								{$t('Please note that there is only 10 mins left for the test to complete, hurry up!')}
+								{$t(
+									'Please note that there is only 10 mins left for the test to complete, hurry up!'
+								)}
 							</p>
 						</Dialog.Description>
 					</div>

--- a/src/lib/testTimerState.svelte.ts
+++ b/src/lib/testTimerState.svelte.ts
@@ -145,6 +145,7 @@ class TestTimerState {
 		this.open = true;
 		this.clearCountdownInterval();
 		this.clearHeartbeatInterval();
+		window.dispatchEvent(new Event('sashakt-time-up'));
 		this.triggerAutoSubmit();
 	}
 

--- a/src/routes/test/[slug]/api/submit-answer/+server.ts
+++ b/src/routes/test/[slug]/api/submit-answer/+server.ts
@@ -61,7 +61,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 					visited: true,
 					bookmarked: bookmarked ?? false,
 					is_reviewed: is_reviewed ?? false,
-					time_spent: time_spent ?? 0
+					...(time_spent !== undefined ? { time_spent } : {})
 				})
 			}
 		);

--- a/src/routes/test/[slug]/api/submit-answer/+server.ts
+++ b/src/routes/test/[slug]/api/submit-answer/+server.ts
@@ -17,13 +17,15 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 		response,
 		candidate,
 		bookmarked,
-		is_reviewed
+		is_reviewed,
+		time_spent
 	}: {
 		question_revision_id: number;
 		response: number[] | string | null;
 		candidate: TCandidate;
 		bookmarked?: boolean;
 		is_reviewed?: boolean;
+		time_spent?: number;
 	} = await request.json();
 
 	if (
@@ -58,7 +60,8 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 						: null,
 					visited: true,
 					bookmarked: bookmarked ?? false,
-					is_reviewed: is_reviewed ?? false
+					is_reviewed: is_reviewed ?? false,
+					time_spent: time_spent ?? 0
 				})
 			}
 		);

--- a/src/routes/test/[slug]/api/submit-answer/+server.ts
+++ b/src/routes/test/[slug]/api/submit-answer/+server.ts
@@ -61,7 +61,12 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 					visited: true,
 					bookmarked: bookmarked ?? false,
 					is_reviewed: is_reviewed ?? false,
-					...(time_spent !== undefined ? { time_spent } : {})
+					...(typeof time_spent === 'number' &&
+					Number.isFinite(time_spent) &&
+					Number.isSafeInteger(time_spent) &&
+					time_spent >= 0
+						? { time_spent }
+						: {})
 				})
 			}
 		);

--- a/src/routes/test/[slug]/api/submit-answer/+server.ts
+++ b/src/routes/test/[slug]/api/submit-answer/+server.ts
@@ -21,7 +21,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 		time_spent
 	}: {
 		question_revision_id: number;
-		response: number[] | string | null;
+		response?: number[] | string | null;
 		candidate: TCandidate;
 		bookmarked?: boolean;
 		is_reviewed?: boolean;
@@ -53,14 +53,17 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
 					question_revision_id,
-					response: response
-						? typeof response === 'string'
-							? response
-							: JSON.stringify(response)
-						: null,
-					visited: true,
-					bookmarked: bookmarked ?? false,
-					is_reviewed: is_reviewed ?? false,
+					...(response !== undefined
+						? {
+								response: response
+									? typeof response === 'string'
+										? response
+										: JSON.stringify(response)
+									: null,
+								...(bookmarked !== undefined ? { bookmarked } : {}),
+								...(is_reviewed !== undefined ? { is_reviewed } : {})
+							}
+						: {}),
 					...(typeof time_spent === 'number' &&
 					Number.isFinite(time_spent) &&
 					Number.isSafeInteger(time_spent) &&

--- a/src/routes/test/[slug]/api/submit-answer/+server.ts
+++ b/src/routes/test/[slug]/api/submit-answer/+server.ts
@@ -53,6 +53,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
 					question_revision_id,
+					visited: true,
 					...(response !== undefined
 						? {
 								response: response

--- a/src/routes/test/[slug]/api/submit-answer/server.test.ts
+++ b/src/routes/test/[slug]/api/submit-answer/server.test.ts
@@ -244,7 +244,7 @@ describe('POST /test/[slug]/api/submit-answer', () => {
 		);
 	});
 
-	it('should default bookmarked to false when not provided', async () => {
+	it('should omit bookmarked from backend payload when not provided', async () => {
 		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
 		vi.mocked(fetch).mockResolvedValueOnce(
 			createMockResponse({ success: true }) as unknown as Response
@@ -260,12 +260,8 @@ describe('POST /test/[slug]/api/submit-answer', () => {
 
 		expect(response.status).toBe(200);
 		expect(fetch).toHaveBeenCalledTimes(1);
-		expect(fetch).toHaveBeenCalledWith(
-			expect.any(String),
-			expect.objectContaining({
-				body: expect.stringContaining('"bookmarked":false')
-			})
-		);
+		const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+		expect(body.bookmarked).toBeUndefined();
 	});
 
 	it('should return 500 when backend API fails', async () => {

--- a/src/routes/test/[slug]/api/submit-answer/server.test.ts
+++ b/src/routes/test/[slug]/api/submit-answer/server.test.ts
@@ -331,4 +331,77 @@ describe('POST /test/[slug]/api/submit-answer', () => {
 		expect(data.success).toBe(false);
 		expect(data.error).toBe('Connection refused');
 	});
+
+	describe('time_spent validation', () => {
+		const validRequest = (time_spent: unknown) =>
+			createMockRequest({ question_revision_id: 1, response: [101], candidate: mockCandidate, time_spent });
+
+		beforeEach(() => {
+			vi.mocked(getCandidate).mockReturnValue(mockCandidate);
+			vi.mocked(fetch).mockResolvedValue(
+				createMockResponse({ success: true }) as unknown as Response
+			);
+		});
+
+		it('forwards a valid positive integer time_spent to the backend', async () => {
+			const response = await POST({ request: validRequest(30), cookies: createMockCookies() } as any);
+			expect(response.status).toBe(200);
+			expect(fetch).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({ body: expect.stringContaining('"time_spent":30') })
+			);
+		});
+
+		it('forwards time_spent of 0', async () => {
+			const response = await POST({ request: validRequest(0), cookies: createMockCookies() } as any);
+			expect(response.status).toBe(200);
+			expect(fetch).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({ body: expect.stringContaining('"time_spent":0') })
+			);
+		});
+
+		it('omits time_spent when value is null', async () => {
+			await POST({ request: validRequest(null), cookies: createMockCookies() } as any);
+			const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+			expect(body).not.toHaveProperty('time_spent');
+		});
+
+		it('omits time_spent when value is a string', async () => {
+			await POST({ request: validRequest('10'), cookies: createMockCookies() } as any);
+			const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+			expect(body).not.toHaveProperty('time_spent');
+		});
+
+		it('omits time_spent when value is negative', async () => {
+			await POST({ request: validRequest(-5), cookies: createMockCookies() } as any);
+			const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+			expect(body).not.toHaveProperty('time_spent');
+		});
+
+		it('omits time_spent when value is Infinity', async () => {
+			await POST({ request: validRequest(Infinity), cookies: createMockCookies() } as any);
+			const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+			expect(body).not.toHaveProperty('time_spent');
+		});
+
+		it('omits time_spent when value is NaN', async () => {
+			await POST({ request: validRequest(NaN), cookies: createMockCookies() } as any);
+			const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+			expect(body).not.toHaveProperty('time_spent');
+		});
+
+		it('omits time_spent when value is an unsafe large number', async () => {
+			await POST({ request: validRequest(Number.MAX_SAFE_INTEGER + 1), cookies: createMockCookies() } as any);
+			const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+			expect(body).not.toHaveProperty('time_spent');
+		});
+
+		it('still saves the answer successfully when time_spent is invalid', async () => {
+			const response = await POST({ request: validRequest('bad'), cookies: createMockCookies() } as any);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.success).toBe(true);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #223 
This PR depends on https://github.com/sashakt-platform/sashakt-core/pull/549



The issue checks below scenarios

1. Tracks time only for single question per page
2. Time tracking takes help of local storage, So tracking is not lost on page refresh or tab closure
3. Considers scenarios where test can be paused.
4. Considers scenarios where immediate feedback for question is available. Stops tracking time once feedback received.
5. Sends time of current question when submitted or test is over


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-question time tracking with configurable pause behavior when the tab is inactive.
  * Tracked time is saved across tab changes and submitted before answer submission or feedback viewing.
  * Answer submissions now support validated time-spent information.
* **Bug Fixes**
  * Improved timer cleanup and prevented duplicate time counting.
* **Tests**
  * Added coverage for timer persistence, visibility changes, cleanup, and time-spent validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->