### PR TITLE
Resume on saved current question across devices (#528)

### DIFF
--- a/src/lib/components/LandingPage.svelte
+++ b/src/lib/components/LandingPage.svelte
@@ -165,7 +165,8 @@
 	<div class="mx-auto max-w-xl lg:flex lg:items-center lg:gap-4">
 		<p class="text-muted-foreground mb-2 text-center text-sm leading-[1.4] lg:mb-0 lg:text-left">
 			{$t(
-				'By clicking "Start Test," you confirm that you have read and understood all instructions.'
+				'By clicking "{action}," you confirm that you have read and understood all instructions.',
+				{ values: { action: startLabel } }
 			)}
 		</p>
 		<div class="lg:shrink-0">

--- a/src/lib/components/LandingPage.svelte
+++ b/src/lib/components/LandingPage.svelte
@@ -16,10 +16,17 @@
 	import RichText from './RichText.svelte';
 	import { t } from 'svelte-i18n';
 
-	let { testDetails, showProfileForm = $bindable() } = $props();
+	let { testDetails, isResumed = false, showProfileForm = $bindable() } = $props();
 
 	let isStarting = $state(false);
 	let createError = $state<string | null>(null);
+
+	// On resume the pre-test form/OMR choice was already completed, so the button
+	// starts the attempt directly (like a test with no form) and reads "Resume".
+	const usesStartFlow = $derived(
+		!isResumed && (testDetails.omr === 'OPTIONAL' || !!testDetails.form)
+	);
+	const startLabel = $derived(isResumed ? $t('Resume Test') : $t('Start Test'));
 
 	function handleStart() {
 		if (page.data?.timeToBegin === 0) {
@@ -163,9 +170,9 @@
 		</p>
 		<div class="lg:shrink-0">
 			{#if page.data?.timeToBegin === 0}
-				{#if testDetails.omr === 'OPTIONAL' || testDetails.form}
+				{#if usesStartFlow}
 					<Button onclick={handleStart} class="w-full lg:w-auto">
-						{$t('Start Test')} →
+						{startLabel} →
 					</Button>
 				{:else}
 					<form method="POST" action="?/createCandidate" use:enhance={handleCreateCandidateEnhance}>
@@ -180,16 +187,16 @@
 							{#if isStarting}
 								<Spinner />
 							{/if}
-							{$t('Start Test')} →
+							{startLabel} →
 						</Button>
 					</form>
 				{/if}
 			{:else}
 				<Dialog.Root>
 					<Dialog.Trigger class={`w-full lg:w-auto ${buttonVariants({ variant: 'default' })}`}>
-						{$t('Start Test')} →
+						{startLabel} →
 					</Dialog.Trigger>
-					{#if testDetails.omr === 'OPTIONAL' || testDetails.form}
+					{#if usesStartFlow}
 						<PreTestTimer timeLeft={page.data?.timeToBegin} bind:showProfileForm />
 					{:else}
 						<PreTestTimer timeLeft={page.data?.timeToBegin} />

--- a/src/lib/components/LandingPage.svelte
+++ b/src/lib/components/LandingPage.svelte
@@ -16,10 +16,21 @@
 	import RichText from './RichText.svelte';
 	import { t } from 'svelte-i18n';
 
-	let { testDetails, isResumed = false, showProfileForm = $bindable() } = $props();
+	let {
+		testDetails,
+		isResumed = false,
+		isExternalLaunch = false,
+		showProfileForm = $bindable()
+	} = $props();
 
 	let isStarting = $state(false);
 	let createError = $state<string | null>(null);
+
+	// This org only allows candidates who arrive from their student portal. Say so
+	// here rather than letting them fill in the form and only then be turned away.
+	const isBlockedAnonymous = $derived(
+		testDetails.blocks_anonymous_start === true && !isExternalLaunch
+	);
 
 	// On resume the pre-test form/OMR choice was already completed, so the button
 	// starts the attempt directly (like a test with no form) and reads "Resume".
@@ -164,13 +175,21 @@
 <div class="fixed bottom-0 z-20 w-screen border-t bg-white px-4 py-4">
 	<div class="mx-auto max-w-xl lg:flex lg:items-center lg:gap-4">
 		<p class="text-muted-foreground mb-2 text-center text-sm leading-[1.4] lg:mb-0 lg:text-left">
-			{$t(
-				'By clicking "{action}," you confirm that you have read and understood all instructions.',
-				{ values: { action: startLabel } }
-			)}
+			{#if isBlockedAnonymous}
+				{$t('Please open this test from your student portal.')}
+			{:else}
+				{$t(
+					'By clicking "{action}," you confirm that you have read and understood all instructions.',
+					{ values: { action: startLabel } }
+				)}
+			{/if}
 		</p>
 		<div class="lg:shrink-0">
-			{#if page.data?.timeToBegin === 0}
+			{#if isBlockedAnonymous}
+				<Button class="w-full lg:w-auto" disabled>
+					{startLabel} →
+				</Button>
+			{:else if page.data?.timeToBegin === 0}
 				{#if usesStartFlow}
 					<Button onclick={handleStart} class="w-full lg:w-auto">
 						{startLabel} →

--- a/src/lib/components/LandingPage.svelte.test.ts
+++ b/src/lib/components/LandingPage.svelte.test.ts
@@ -296,4 +296,36 @@ describe('Support for Localization', () => {
 			).toBeInTheDocument();
 		});
 	});
+
+	it('should disable the start button when the org blocks anonymous starts', async () => {
+		render(LandingPage, {
+			props: {
+				testDetails: { ...defaultTestDetails, blocks_anonymous_start: true }
+			}
+		});
+
+		await waitFor(() => {
+			expect(
+				screen.getByText('Please open this test from your student portal.')
+			).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: /Start Test/ })).toBeDisabled();
+		});
+	});
+
+	it('should still allow an external launch when anonymous starts are blocked', async () => {
+		// The candidate came from the portal, so the block must not apply to them.
+		render(LandingPage, {
+			props: {
+				testDetails: { ...defaultTestDetails, blocks_anonymous_start: true },
+				isExternalLaunch: true
+			}
+		});
+
+		await waitFor(() => {
+			expect(
+				screen.queryByText('Please open this test from your student portal.')
+			).not.toBeInTheDocument();
+			expect(screen.getByRole('button', { name: /Start Test/ })).not.toBeDisabled();
+		});
+	});
 });

--- a/src/lib/components/OmrSheet.svelte
+++ b/src/lib/components/OmrSheet.svelte
@@ -7,7 +7,7 @@
 	import { canAttemptAllQuestions, normalizeTestQuestions } from '$lib/helpers/questionSetHelpers';
 	import { answeredAllMandatory } from '$lib/helpers/testFunctionalities';
 	import { createFormEnhanceHandler } from '$lib/helpers/formErrorHandler';
-	import { createTestSessionStore } from '$lib/helpers/testSession';
+	import { createTestSessionStore, getInitialSelections } from '$lib/helpers/testSession';
 	import { question_type_enum, type TCandidate, type TQuestion, type TSelection } from '$lib/types';
 	import { t } from 'svelte-i18n';
 	import RichText from './RichText.svelte';
@@ -28,7 +28,10 @@
 	const questions: TQuestion[] = $derived(normalizedQuestionData.questions);
 	const sectionByQuestionId = $derived(normalizedQuestionData.sectionByQuestionId);
 	const sessionStore = createTestSessionStore(candidate);
-	let selections = $state<TSelection[]>(sessionStore.current.selections);
+	// Seed from the server when this device has no local cache (cross-device resume).
+	let selections = $state<TSelection[]>(
+		getInitialSelections(sessionStore.current.selections, testQuestions?.saved_answers)
+	);
 	let submittingQuestion = $state<number | null>(null);
 
 	let isSubmittingTest = $state(false);
@@ -58,10 +61,10 @@
 	});
 </script>
 
-<div class="min-h-screen bg-muted p-4 pb-20 lg:p-6 lg:pb-20">
-	<h1 class="mb-6 text-center text-xl font-semibold text-foreground">{$t('OMR Sheet')}</h1>
+<div class="bg-muted min-h-screen p-4 pb-20 lg:p-6 lg:pb-20">
+	<h1 class="text-foreground mb-6 text-center text-xl font-semibold">{$t('OMR Sheet')}</h1>
 
-	<div class="mx-auto flex max-w-4xl flex-col gap-5 rounded-2xl bg-card p-4 shadow-sm sm:p-6">
+	<div class="bg-card mx-auto flex max-w-4xl flex-col gap-5 rounded-2xl p-4 shadow-sm sm:p-6">
 		{#each questions as question, i (question.id)}
 			{@const section = sectionByQuestionId.get(question.id) ?? null}
 			{#if section && i === 0}
@@ -245,7 +248,7 @@
 						<Dialog.Close class="flex-1 sm:flex-none">
 							<Button
 								variant="outline"
-								class="w-full border-primary text-primary hover:text-primary"
+								class="border-primary text-primary hover:text-primary w-full"
 								disabled={isSubmittingTest}
 							>
 								{$t('Cancel')}

--- a/src/lib/components/OmrSheet.svelte.test.ts
+++ b/src/lib/components/OmrSheet.svelte.test.ts
@@ -31,7 +31,8 @@ vi.mock('$app/state', () => ({
 }));
 
 vi.mock('$lib/helpers/testSession', () => ({
-	createTestSessionStore: vi.fn(() => ({ current: { selections: [] } }))
+	createTestSessionStore: vi.fn(() => ({ current: { selections: [] } })),
+	getInitialSelections: vi.fn((local: unknown) => local)
 }));
 
 vi.mock('$lib/helpers/testFunctionalities', () => ({
@@ -383,7 +384,10 @@ describe('OmrSheet', () => {
 			withSelections([
 				{
 					question_revision_id: mockMultipleChoiceQuestion.id,
-					response: [mockMultipleChoiceQuestion.options[0].id, mockMultipleChoiceQuestion.options[1].id],
+					response: [
+						mockMultipleChoiceQuestion.options[0].id,
+						mockMultipleChoiceQuestion.options[1].id
+					],
 					visited: true,
 					time_spent: 0,
 					bookmarked: false,
@@ -1218,7 +1222,9 @@ describe('OmrSheet', () => {
 			await fireEvent.click(screen.getAllByRole('button', { name: /^submit$/i })[0]);
 
 			await screen.findByRole('dialog');
-			expect(screen.getByText(/Please make sure all mandatory questions are answered/)).toBeInTheDocument();
+			expect(
+				screen.getByText(/Please make sure all mandatory questions are answered/)
+			).toBeInTheDocument();
 		});
 
 		it('shows an Okay button that closes the dialog', async () => {

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -13,7 +13,7 @@
 	import { canAttemptAllQuestions, normalizeTestQuestions } from '$lib/helpers/questionSetHelpers';
 	import { countQuestionStatuses } from '$lib/helpers/questionPaletteHelpers';
 	import { answeredAllMandatory, answeredCurrentMandatory } from '$lib/helpers/testFunctionalities';
-	import { createTestSessionStore } from '$lib/helpers/testSession';
+	import { createTestSessionStore, mapSavedAnswersToSelections } from '$lib/helpers/testSession';
 	import { createFormEnhanceHandler } from '$lib/helpers/formErrorHandler';
 	import { navState } from '$lib/navState.svelte';
 	import type { TQuestion, TSelection, TQuestionSetCandidate } from '$lib/types';
@@ -53,7 +53,17 @@
 	const perPage = testQuestions.question_pagination || totalQuestions;
 
 	const sessionStore = createTestSessionStore(candidate);
-	let selectedQuestions = $state(sessionStore.current.selections);
+
+	// Seed on-screen answers from the server when this device has no local cache
+	// yet (e.g. resuming on another device). localStorage stays the fast local
+	// cache; the server's saved answers are the cross-device source of truth.
+	function getInitialSelections(): TSelection[] {
+		if (sessionStore.current.selections.length > 0) {
+			return sessionStore.current.selections;
+		}
+		return mapSavedAnswersToSelections(testQuestions?.saved_answers);
+	}
+	let selectedQuestions = $state(getInitialSelections());
 
 	// set paginiation related properties.
 	// Prefer the server-saved current question (so the test resumes on another

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -57,27 +57,29 @@
 	// Seed on-screen answers from the server when this device has no local cache
 	// yet (e.g. resuming on another device). localStorage stays the fast local
 	// cache; the server's saved answers are the cross-device source of truth.
-	let selectedQuestions = $state(
-		getInitialSelections(sessionStore.current.selections, testQuestions?.saved_answers)
-	);
+	function getInitialSelectionsForLoad(): TSelection[] {
+		return getInitialSelections(sessionStore.current.selections, testQuestions?.saved_answers);
+	}
+	let selectedQuestions = $state(getInitialSelectionsForLoad());
 
 	// set paginiation related properties.
-	// Prefer the server-saved current question (so the test resumes on another
-	// device with the same login), then fall back to the locally stored page.
-	function getInitialPage(): number {
+	// Prefer the exact server-saved current question (so the test resumes on the
+	// same question on another device), then fall back to the locally stored page.
+	function getInitialQuestionIndex(): number {
 		const serverRevisionId = testQuestions?.candidate_test?.current_question_revision_id;
 		if (serverRevisionId != null) {
 			const index = questions.findIndex((question) => question.id === serverRevisionId);
-			if (index >= 0) return Math.floor(index / perPage) + 1;
+			if (index >= 0) return index;
 		}
-		return sessionStore.current.currentPage || 1;
+		// localStorage only remembers the page, not the exact question
+		return ((sessionStore.current.currentPage || 1) - 1) * perPage;
 	}
-	const initialPage = getInitialPage();
-	let paginationPage = $state(initialPage);
+	const initialQuestionIndex = getInitialQuestionIndex();
+	let paginationPage = $state(Math.floor(initialQuestionIndex / perPage) + 1);
 	let paginationReady = $state(false);
 
 	// question palette - track which question is currently selected
-	let currentQuestionIndex = $state((initialPage - 1) * perPage);
+	let currentQuestionIndex = $state(initialQuestionIndex);
 	const paletteStats = $derived(countQuestionStatuses(questions, selectedQuestions));
 	const markedForReviewCount = $derived(
 		selectedQuestions.filter((s: TSelection) => s.bookmarked).length
@@ -112,14 +114,8 @@
 		}).catch((error) => console.error('Failed to sync current position:', error));
 	}
 
-	// navigate to a specific question by index
-	function navigateToQuestion(questionIndex: number) {
-		const targetPage = Math.floor(questionIndex / perPage) + 1;
-		paginationPage = targetPage;
-		currentQuestionIndex = questionIndex;
-		syncCurrentPosition(questionIndex);
-
-		// scroll to the specific question after page renders
+	// scroll a specific question into view after the page renders
+	function scrollToQuestion(questionIndex: number) {
 		setTimeout(() => {
 			const element = document.getElementById(`question-${questionIndex}`);
 			if (element) {
@@ -128,6 +124,14 @@
 				window.scrollTo({ top: elementPosition - offset, behavior: 'smooth' });
 			}
 		}, 50);
+	}
+
+	// navigate to a specific question by index
+	function navigateToQuestion(questionIndex: number) {
+		paginationPage = Math.floor(questionIndex / perPage) + 1;
+		currentQuestionIndex = questionIndex;
+		syncCurrentPosition(questionIndex);
+		scrollToQuestion(questionIndex);
 	}
 
 	// sync page number to localStorage when page changes
@@ -144,6 +148,8 @@
 	$effect(() => {
 		const timer = setTimeout(() => {
 			paginationReady = true;
+			// land on the exact resumed question, not just its page
+			scrollToQuestion(currentQuestionIndex);
 		}, 10);
 		return () => clearTimeout(timer);
 	});

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -13,7 +13,11 @@
 	import { canAttemptAllQuestions, normalizeTestQuestions } from '$lib/helpers/questionSetHelpers';
 	import { countQuestionStatuses } from '$lib/helpers/questionPaletteHelpers';
 	import { answeredAllMandatory, answeredCurrentMandatory } from '$lib/helpers/testFunctionalities';
-	import { createTestSessionStore, getInitialSelections } from '$lib/helpers/testSession';
+	import {
+		createTestSessionStore,
+		getInitialSelections,
+		resolveInitialQuestionIndex
+	} from '$lib/helpers/testSession';
 	import { createFormEnhanceHandler } from '$lib/helpers/formErrorHandler';
 	import { navState } from '$lib/navState.svelte';
 	import type { TQuestion, TSelection, TQuestionSetCandidate } from '$lib/types';
@@ -62,17 +66,15 @@
 	}
 	let selectedQuestions = $state(getInitialSelectionsForLoad());
 
-	// set paginiation related properties.
 	// Prefer the exact server-saved current question (so the test resumes on the
 	// same question on another device), then fall back to the locally stored page.
 	function getInitialQuestionIndex(): number {
-		const serverRevisionId = testQuestions?.candidate_test?.current_question_revision_id;
-		if (serverRevisionId != null) {
-			const index = questions.findIndex((question) => question.id === serverRevisionId);
-			if (index >= 0) return index;
-		}
-		// localStorage only remembers the page, not the exact question
-		return ((sessionStore.current.currentPage || 1) - 1) * perPage;
+		return resolveInitialQuestionIndex(
+			testQuestions?.candidate_test?.current_question_revision_id,
+			questions.map((question) => question.id),
+			perPage,
+			sessionStore.current.currentPage
+		);
 	}
 	const initialQuestionIndex = getInitialQuestionIndex();
 	let paginationPage = $state(Math.floor(initialQuestionIndex / perPage) + 1);

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -55,12 +55,23 @@
 	const sessionStore = createTestSessionStore(candidate);
 	let selectedQuestions = $state(sessionStore.current.selections);
 
-	// set paginiation related properties
-	let paginationPage = $state(sessionStore.current.currentPage || 1);
+	// set paginiation related properties.
+	// Prefer the server-saved current question (so the test resumes on another
+	// device with the same login), then fall back to the locally stored page.
+	function getInitialPage(): number {
+		const serverRevisionId = testQuestions?.candidate_test?.current_question_revision_id;
+		if (serverRevisionId != null) {
+			const index = questions.findIndex((question) => question.id === serverRevisionId);
+			if (index >= 0) return Math.floor(index / perPage) + 1;
+		}
+		return sessionStore.current.currentPage || 1;
+	}
+	const initialPage = getInitialPage();
+	let paginationPage = $state(initialPage);
 	let paginationReady = $state(false);
 
 	// question palette - track which question is currently selected
-	let currentQuestionIndex = $state((sessionStore.current.currentPage - 1) * perPage || 0);
+	let currentQuestionIndex = $state((initialPage - 1) * perPage);
 	const paletteStats = $derived(countQuestionStatuses(questions, selectedQuestions));
 	const markedForReviewCount = $derived(
 		selectedQuestions.filter((s: TSelection) => s.bookmarked).length
@@ -83,11 +94,24 @@
 		};
 	});
 
+	// Persist the current question server-side so the attempt can resume on
+	// another device. Fire-and-forget, mirroring the answer sync.
+	function syncCurrentPosition(questionIndex: number) {
+		const currentQuestion = questions[questionIndex];
+		if (!currentQuestion) return;
+		fetch(`/test/${page.params.slug}/api/current-position`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ question_revision_id: currentQuestion.id, candidate })
+		}).catch((error) => console.error('Failed to sync current position:', error));
+	}
+
 	// navigate to a specific question by index
 	function navigateToQuestion(questionIndex: number) {
 		const targetPage = Math.floor(questionIndex / perPage) + 1;
 		paginationPage = targetPage;
 		currentQuestionIndex = questionIndex;
+		syncCurrentPosition(questionIndex);
 
 		// scroll to the specific question after page renders
 		setTimeout(() => {
@@ -127,6 +151,7 @@
 	// scroll to top and update current question index when page changes
 	function handlePageChange(newPage: number) {
 		currentQuestionIndex = (newPage - 1) * perPage;
+		syncCurrentPosition(currentQuestionIndex);
 		window.scrollTo({ top: 0, behavior: 'instant' });
 	}
 
@@ -141,7 +166,9 @@
 {#snippet mandatoryQuestionDialog(lastPage: boolean)}
 	<Dialog.Content class="gap-0 overflow-hidden p-0 sm:max-w-100">
 		<div class="bg-muted px-6 pt-6 pr-12 pb-4">
-			<Dialog.Title class="text-base font-semibold">{$t('Answer all mandatory questions!')}</Dialog.Title>
+			<Dialog.Title class="text-base font-semibold"
+				>{$t('Answer all mandatory questions!')}</Dialog.Title
+			>
 		</div>
 
 		<div class="border-border border-t"></div>
@@ -322,7 +349,11 @@
 
 											<div class="bg-card flex justify-end gap-3 px-6 pb-6">
 												<Dialog.Close class="flex-1 sm:flex-none">
-													<Button variant="outline" disabled={isSubmittingTest} class="w-full border-primary text-primary hover:text-primary">
+													<Button
+														variant="outline"
+														disabled={isSubmittingTest}
+														class="border-primary text-primary hover:text-primary w-full"
+													>
 														{$t('Cancel')}
 													</Button>
 												</Dialog.Close>

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -13,7 +13,7 @@
 	import { canAttemptAllQuestions, normalizeTestQuestions } from '$lib/helpers/questionSetHelpers';
 	import { countQuestionStatuses } from '$lib/helpers/questionPaletteHelpers';
 	import { answeredAllMandatory, answeredCurrentMandatory } from '$lib/helpers/testFunctionalities';
-	import { createTestSessionStore, mapSavedAnswersToSelections } from '$lib/helpers/testSession';
+	import { createTestSessionStore, getInitialSelections } from '$lib/helpers/testSession';
 	import { createFormEnhanceHandler } from '$lib/helpers/formErrorHandler';
 	import { navState } from '$lib/navState.svelte';
 	import type { TQuestion, TSelection, TQuestionSetCandidate } from '$lib/types';
@@ -57,13 +57,9 @@
 	// Seed on-screen answers from the server when this device has no local cache
 	// yet (e.g. resuming on another device). localStorage stays the fast local
 	// cache; the server's saved answers are the cross-device source of truth.
-	function getInitialSelections(): TSelection[] {
-		if (sessionStore.current.selections.length > 0) {
-			return sessionStore.current.selections;
-		}
-		return mapSavedAnswersToSelections(testQuestions?.saved_answers);
-	}
-	let selectedQuestions = $state(getInitialSelections());
+	let selectedQuestions = $state(
+		getInitialSelections(sessionStore.current.selections, testQuestions?.saved_answers)
+	);
 
 	// set paginiation related properties.
 	// Prefer the server-saved current question (so the test resumes on another

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -108,12 +108,15 @@
 	// another device. Fire-and-forget, mirroring the answer sync.
 	function syncCurrentPosition(questionIndex: number) {
 		const currentQuestion = questions[questionIndex];
-		if (!currentQuestion) return;
-		fetch(`/test/${page.params.slug}/api/current-position`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ question_revision_id: currentQuestion.id, candidate })
-		}).catch((error) => console.error('Failed to sync current position:', error));
+		const slug = page.params?.slug;
+		if (!currentQuestion || !slug) return;
+		Promise.resolve(
+			fetch(`/test/${slug}/api/current-position`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ question_revision_id: currentQuestion.id, candidate })
+			})
+		).catch((error) => console.error('Failed to sync current position:', error));
 	}
 
 	// scroll a specific question into view after the page renders

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -116,7 +116,15 @@
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ question_revision_id: currentQuestion.id, candidate })
 			})
-		).catch((error) => console.error('Failed to sync current position:', error));
+		)
+			.then((response) => {
+				// fetch only rejects on network failure, so a 4xx/5xx would otherwise
+				// pass silently and leave the resume position stale.
+				if (!response.ok) {
+					console.error('Failed to sync current position:', response.status);
+				}
+			})
+			.catch((error) => console.error('Failed to sync current position:', error));
 	}
 
 	// scroll a specific question into view after the page renders

--- a/src/lib/components/Question.svelte.test.ts
+++ b/src/lib/components/Question.svelte.test.ts
@@ -30,7 +30,7 @@ vi.mock('$lib/helpers/testSession', () => ({
 			currentPage: 1
 		}
 	})),
-	mapSavedAnswersToSelections: vi.fn(() => [])
+	getInitialSelections: vi.fn((local: unknown) => local)
 }));
 
 vi.mock('$lib/helpers/formErrorHandler', () => ({

--- a/src/lib/components/Question.svelte.test.ts
+++ b/src/lib/components/Question.svelte.test.ts
@@ -29,7 +29,8 @@ vi.mock('$lib/helpers/testSession', () => ({
 			selections: [],
 			currentPage: 1
 		}
-	}))
+	})),
+	mapSavedAnswersToSelections: vi.fn(() => [])
 }));
 
 vi.mock('$lib/helpers/formErrorHandler', () => ({

--- a/src/lib/components/Question.svelte.test.ts
+++ b/src/lib/components/Question.svelte.test.ts
@@ -30,7 +30,19 @@ vi.mock('$lib/helpers/testSession', () => ({
 			currentPage: 1
 		}
 	})),
-	getInitialSelections: vi.fn((local: unknown) => local)
+	getInitialSelections: vi.fn((local: unknown) => local),
+	resolveInitialQuestionIndex: (
+		rev: number | null | undefined,
+		ids: number[],
+		perPage: number,
+		page: number | null | undefined
+	) => {
+		if (rev != null) {
+			const i = ids.indexOf(rev);
+			if (i >= 0) return i;
+		}
+		return ((page || 1) - 1) * perPage;
+	}
 }));
 
 vi.mock('$lib/helpers/formErrorHandler', () => ({
@@ -77,6 +89,30 @@ describe('Question', () => {
 		await vi.waitFor(() => {
 			expect(screen.getByText(mockQuestions[0].question_text)).toBeInTheDocument();
 		});
+	});
+
+	it('syncs the current question to the backend when navigating via the palette', async () => {
+		// reject so the fire-and-forget error path is exercised too
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.mocked(fetch).mockRejectedValue(new Error('offline'));
+		render(Question, {
+			props: {
+				candidate: mockCandidate,
+				testQuestions,
+				testDetails: { ...mockTestData, show_question_palette: true }
+			}
+		});
+
+		const target = await screen.findByRole('button', { name: /go to question 2/i });
+		await fireEvent.click(target);
+
+		await waitFor(() => {
+			expect(fetch).toHaveBeenCalledWith(
+				'/test/sample-test/api/current-position',
+				expect.objectContaining({ method: 'POST' })
+			);
+		});
+		consoleError.mockRestore();
 	});
 
 	it('should render pagination controls', async () => {

--- a/src/lib/helpers/feedbackHelpers.test.ts
+++ b/src/lib/helpers/feedbackHelpers.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { getQuestionResult, parseMatrixAnswer, getMatrixCellStatus } from './feedbackHelpers';
+import {
+	getQuestionResult,
+	parseMatrixAnswer,
+	getMatrixCellStatus,
+	normalizeFeedbackEntry
+} from './feedbackHelpers';
 import { question_type_enum } from '$lib/types';
 
 describe('getQuestionResult', () => {
@@ -129,7 +134,9 @@ describe('getQuestionResult', () => {
 
 	describe('non-gradable types (fallback)', () => {
 		it('returns unattempted for subjective questions', () => {
-			expect(getQuestionResult(question_type_enum.SUBJECTIVE, 'some answer', [])).toBe('unattempted');
+			expect(getQuestionResult(question_type_enum.SUBJECTIVE, 'some answer', [])).toBe(
+				'unattempted'
+			);
 		});
 	});
 
@@ -140,32 +147,46 @@ describe('getQuestionResult', () => {
 		const wrongSubmitted = JSON.stringify({ '1': [11], '2': [13] });
 
 		it('returns correct when all rows match exactly', () => {
-			expect(getQuestionResult(question_type_enum.MATRIXMATCH, correctSubmitted, correctAnswer)).toBe('correct');
+			expect(
+				getQuestionResult(question_type_enum.MATRIXMATCH, correctSubmitted, correctAnswer)
+			).toBe('correct');
 		});
 
 		it('returns correct regardless of column order within a row', () => {
 			const reordered = JSON.stringify({ '1': [11, 10], '2': [12] });
-			expect(getQuestionResult(question_type_enum.MATRIXMATCH, reordered, correctAnswer)).toBe('correct');
+			expect(getQuestionResult(question_type_enum.MATRIXMATCH, reordered, correctAnswer)).toBe(
+				'correct'
+			);
 		});
 
 		it('returns incorrect when a row has missing columns', () => {
-			expect(getQuestionResult(question_type_enum.MATRIXMATCH, partialSubmitted, correctAnswer)).toBe('incorrect');
+			expect(
+				getQuestionResult(question_type_enum.MATRIXMATCH, partialSubmitted, correctAnswer)
+			).toBe('incorrect');
 		});
 
 		it('returns incorrect when a row has wrong columns', () => {
-			expect(getQuestionResult(question_type_enum.MATRIXMATCH, wrongSubmitted, correctAnswer)).toBe('incorrect');
+			expect(getQuestionResult(question_type_enum.MATRIXMATCH, wrongSubmitted, correctAnswer)).toBe(
+				'incorrect'
+			);
 		});
 
 		it('returns unattempted when submitted is empty JSON object string', () => {
-			expect(getQuestionResult(question_type_enum.MATRIXMATCH, '{}', correctAnswer)).toBe('unattempted');
+			expect(getQuestionResult(question_type_enum.MATRIXMATCH, '{}', correctAnswer)).toBe(
+				'unattempted'
+			);
 		});
 
 		it('returns unattempted when correct answer is empty JSON object string', () => {
-			expect(getQuestionResult(question_type_enum.MATRIXMATCH, correctSubmitted, '{}')).toBe('unattempted');
+			expect(getQuestionResult(question_type_enum.MATRIXMATCH, correctSubmitted, '{}')).toBe(
+				'unattempted'
+			);
 		});
 
 		it('returns unattempted when submitted is empty array (not attempted at all)', () => {
-			expect(getQuestionResult(question_type_enum.MATRIXMATCH, [], correctAnswer)).toBe('unattempted');
+			expect(getQuestionResult(question_type_enum.MATRIXMATCH, [], correctAnswer)).toBe(
+				'unattempted'
+			);
 		});
 	});
 });
@@ -228,5 +249,61 @@ describe('getMatrixCellStatus', () => {
 
 	it('returns missed when submitted map is empty for that row', () => {
 		expect(getMatrixCellStatus(2, 13, {}, correct)).toBe('missed');
+	});
+});
+
+describe('normalizeFeedbackEntry', () => {
+	it('parses a JSON array answer into numbers', () => {
+		expect(
+			normalizeFeedbackEntry({
+				question_revision_id: 1,
+				submitted_answer: '[102]',
+				correct_answer: [102]
+			})
+		).toEqual({ question_revision_id: 1, submitted_answer: [102], correct_answer: [102] });
+	});
+
+	it('parses a multi-choice answer', () => {
+		expect(
+			normalizeFeedbackEntry({
+				question_revision_id: 2,
+				submitted_answer: '[201, 203]',
+				correct_answer: [201, 202]
+			})
+		).toEqual({
+			question_revision_id: 2,
+			submitted_answer: [201, 203],
+			correct_answer: [201, 202]
+		});
+	});
+
+	it('returns an empty array when nothing was submitted', () => {
+		expect(
+			normalizeFeedbackEntry({
+				question_revision_id: 3,
+				submitted_answer: null,
+				correct_answer: [301]
+			}).submitted_answer
+		).toEqual([]);
+	});
+
+	it('keeps a subjective answer as its raw string', () => {
+		expect(
+			normalizeFeedbackEntry({
+				question_revision_id: 4,
+				submitted_answer: 'Because the reaction is exothermic',
+				correct_answer: []
+			}).submitted_answer
+		).toBe('Because the reaction is exothermic');
+	});
+
+	it('keeps a non-array JSON value as its raw string', () => {
+		expect(
+			normalizeFeedbackEntry({
+				question_revision_id: 5,
+				submitted_answer: '42',
+				correct_answer: []
+			}).submitted_answer
+		).toBe('42');
 	});
 });

--- a/src/lib/helpers/feedbackHelpers.ts
+++ b/src/lib/helpers/feedbackHelpers.ts
@@ -8,6 +8,39 @@ export const GRADABLE_QUESTION_TYPES = new Set([
 	question_type_enum.MATRIXMATCH
 ]);
 
+export type TFeedbackEntry = {
+	question_revision_id: number;
+	submitted_answer: number[] | string;
+	correct_answer: number[];
+};
+
+/**
+ * Shape a review-feedback row for the UI.
+ *
+ * The stored answer is a JSON string, so hand over the parsed array where it is
+ * one and the raw string otherwise (subjective answers are plain text).
+ */
+export const normalizeFeedbackEntry = (item: {
+	question_revision_id: number;
+	submitted_answer: string | null;
+	correct_answer: number[];
+}): TFeedbackEntry => {
+	let submitted: number[] | string = [];
+	if (item.submitted_answer) {
+		try {
+			const parsed = JSON.parse(item.submitted_answer);
+			submitted = Array.isArray(parsed) ? parsed : item.submitted_answer;
+		} catch {
+			submitted = item.submitted_answer;
+		}
+	}
+	return {
+		question_revision_id: item.question_revision_id,
+		submitted_answer: submitted,
+		correct_answer: item.correct_answer
+	};
+};
+
 export const parseMatrixAnswer = (
 	raw: string | number[] | null | undefined
 ): Record<string, number[]> => {

--- a/src/lib/helpers/testSession.test.ts
+++ b/src/lib/helpers/testSession.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { mapSavedAnswersToSelections } from './testSession';
+
+describe('mapSavedAnswersToSelections', () => {
+	it('returns an empty list for null/undefined', () => {
+		expect(mapSavedAnswersToSelections(null)).toEqual([]);
+		expect(mapSavedAnswersToSelections(undefined)).toEqual([]);
+	});
+
+	it('parses a JSON-array response into numbers and carries flags', () => {
+		const [selection] = mapSavedAnswersToSelections([
+			{ question_revision_id: 7, response: '[2]', visited: true, bookmarked: true }
+		]);
+		expect(selection).toEqual({
+			question_revision_id: 7,
+			response: [2],
+			visited: true,
+			time_spent: 0,
+			bookmarked: true,
+			is_reviewed: false
+		});
+	});
+
+	it('keeps a subjective string response as-is', () => {
+		const [selection] = mapSavedAnswersToSelections([
+			{ question_revision_id: 8, response: 'my essay answer' }
+		]);
+		expect(selection.response).toBe('my essay answer');
+		expect(selection.visited).toBe(false);
+		expect(selection.bookmarked).toBe(false);
+	});
+
+	it('treats a null response as empty', () => {
+		const [selection] = mapSavedAnswersToSelections([{ question_revision_id: 9, response: null }]);
+		expect(selection.response).toEqual([]);
+	});
+});

--- a/src/lib/helpers/testSession.test.ts
+++ b/src/lib/helpers/testSession.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { getInitialSelections, mapSavedAnswersToSelections } from './testSession';
+import {
+	getInitialSelections,
+	mapSavedAnswersToSelections,
+	resolveInitialQuestionIndex
+} from './testSession';
 
 describe('mapSavedAnswersToSelections', () => {
 	it('returns an empty list for null/undefined', () => {
@@ -68,5 +72,26 @@ describe('getInitialSelections', () => {
 		expect(result).toHaveLength(1);
 		expect(result[0].question_revision_id).toBe(9);
 		expect(result[0].response).toEqual([3]);
+	});
+});
+
+describe('resolveInitialQuestionIndex', () => {
+	const ids = [11, 12, 13, 14, 15, 16, 17];
+
+	it('returns the exact index of the server-saved question', () => {
+		// question 14 is index 3 → page 2 when perPage is 2, but the index is exact
+		expect(resolveInitialQuestionIndex(14, ids, 2, 1)).toBe(3);
+	});
+
+	it('falls back to the first question of the stored page when no server question', () => {
+		expect(resolveInitialQuestionIndex(null, ids, 2, 3)).toBe(4);
+	});
+
+	it('falls back when the saved question is not in the assigned list', () => {
+		expect(resolveInitialQuestionIndex(999, ids, 5, 2)).toBe(5);
+	});
+
+	it('defaults to the first question when there is no stored page', () => {
+		expect(resolveInitialQuestionIndex(null, ids, 5, undefined)).toBe(0);
 	});
 });

--- a/src/lib/helpers/testSession.test.ts
+++ b/src/lib/helpers/testSession.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mapSavedAnswersToSelections } from './testSession';
+import { getInitialSelections, mapSavedAnswersToSelections } from './testSession';
 
 describe('mapSavedAnswersToSelections', () => {
 	it('returns an empty list for null/undefined', () => {
@@ -7,18 +7,29 @@ describe('mapSavedAnswersToSelections', () => {
 		expect(mapSavedAnswersToSelections(undefined)).toEqual([]);
 	});
 
-	it('parses a JSON-array response into numbers and carries flags', () => {
+	it('parses a JSON-array response into numbers and carries flags + time', () => {
 		const [selection] = mapSavedAnswersToSelections([
-			{ question_revision_id: 7, response: '[2]', visited: true, bookmarked: true }
+			{
+				question_revision_id: 7,
+				response: '[2]',
+				visited: true,
+				time_spent: 42,
+				bookmarked: true
+			}
 		]);
 		expect(selection).toEqual({
 			question_revision_id: 7,
 			response: [2],
 			visited: true,
-			time_spent: 0,
+			time_spent: 42,
 			bookmarked: true,
 			is_reviewed: false
 		});
+	});
+
+	it('defaults time_spent to 0 when the server has no recorded time', () => {
+		const [selection] = mapSavedAnswersToSelections([{ question_revision_id: 7, response: '[2]' }]);
+		expect(selection.time_spent).toBe(0);
 	});
 
 	it('keeps a subjective string response as-is', () => {
@@ -33,5 +44,29 @@ describe('mapSavedAnswersToSelections', () => {
 	it('treats a null response as empty', () => {
 		const [selection] = mapSavedAnswersToSelections([{ question_revision_id: 9, response: null }]);
 		expect(selection.response).toEqual([]);
+	});
+
+	it('carries reviewed state and the already-seen correct answer', () => {
+		const [selection] = mapSavedAnswersToSelections([
+			{ question_revision_id: 7, response: '[2]', is_reviewed: true, correct_answer: [2] }
+		]);
+		expect(selection.is_reviewed).toBe(true);
+		expect(selection.correct_answer).toEqual([2]);
+	});
+});
+
+describe('getInitialSelections', () => {
+	it('uses the local selections when present', () => {
+		const local = [
+			{ question_revision_id: 1, response: [1], visited: true, time_spent: 0, bookmarked: false }
+		];
+		expect(getInitialSelections(local, [{ question_revision_id: 9, response: '[3]' }])).toBe(local);
+	});
+
+	it('falls back to the server saved answers when local is empty', () => {
+		const result = getInitialSelections([], [{ question_revision_id: 9, response: '[3]' }]);
+		expect(result).toHaveLength(1);
+		expect(result[0].question_revision_id).toBe(9);
+		expect(result[0].response).toEqual([3]);
 	});
 });

--- a/src/lib/helpers/testSession.test.ts
+++ b/src/lib/helpers/testSession.test.ts
@@ -94,4 +94,16 @@ describe('resolveInitialQuestionIndex', () => {
 	it('defaults to the first question when there is no stored page', () => {
 		expect(resolveInitialQuestionIndex(null, ids, 5, undefined)).toBe(0);
 	});
+
+	it('clamps a stored page that points past the end of the test', () => {
+		expect(resolveInitialQuestionIndex(null, ids, 5, 99)).toBe(ids.length - 1);
+	});
+
+	it('clamps a negative stored page', () => {
+		expect(resolveInitialQuestionIndex(null, ids, 5, -3)).toBe(0);
+	});
+
+	it('stays at zero when there are no questions', () => {
+		expect(resolveInitialQuestionIndex(null, [], 5, 4)).toBe(0);
+	});
 });

--- a/src/lib/helpers/testSession.ts
+++ b/src/lib/helpers/testSession.ts
@@ -18,7 +18,10 @@ export type TSavedAnswer = {
 	question_revision_id: number;
 	response: string | null;
 	visited?: boolean;
+	time_spent?: number | null;
 	bookmarked?: boolean;
+	is_reviewed?: boolean;
+	correct_answer?: number[] | number | null | string;
 };
 
 const parseSavedResponse = (raw: string | null): number[] | string => {
@@ -43,8 +46,19 @@ export const mapSavedAnswersToSelections = (
 		question_revision_id: answer.question_revision_id,
 		response: parseSavedResponse(answer.response),
 		visited: answer.visited ?? false,
-		time_spent: 0,
+		time_spent: answer.time_spent ?? 0,
 		bookmarked: answer.bookmarked ?? false,
-		is_reviewed: false
+		is_reviewed: answer.is_reviewed ?? false,
+		correct_answer: answer.correct_answer ?? undefined
 	}));
 };
+
+/**
+ * The selections a fresh page load should start with: the locally cached ones
+ * if present, otherwise seeded from the server (resuming on another device).
+ */
+export const getInitialSelections = (
+	localSelections: TSelection[],
+	savedAnswers: TSavedAnswer[] | null | undefined
+): TSelection[] =>
+	localSelections.length > 0 ? localSelections : mapSavedAnswersToSelections(savedAnswers);

--- a/src/lib/helpers/testSession.ts
+++ b/src/lib/helpers/testSession.ts
@@ -1,4 +1,4 @@
-import type { TCandidate, TTestSession } from '$lib/types';
+import type { TCandidate, TSelection, TTestSession } from '$lib/types';
 import { LocalStorage } from '$lib/localStore.svelte';
 
 export const createTestSessionStore = (candidate: TCandidate) => {
@@ -12,4 +12,39 @@ export const createTestSessionStore = (candidate: TCandidate) => {
 		`sashakt-session-${candidate.candidate_test_id}`,
 		initialSession
 	);
+};
+
+export type TSavedAnswer = {
+	question_revision_id: number;
+	response: string | null;
+	visited?: boolean;
+	bookmarked?: boolean;
+};
+
+const parseSavedResponse = (raw: string | null): number[] | string => {
+	if (raw == null) return [];
+	try {
+		const parsed = JSON.parse(raw);
+		return Array.isArray(parsed) ? parsed : raw;
+	} catch {
+		return raw;
+	}
+};
+
+/**
+ * Map the candidate's server-saved answers into the in-memory selection shape,
+ * used to seed the UI when a device has no local cache yet (cross-device resume).
+ */
+export const mapSavedAnswersToSelections = (
+	savedAnswers: TSavedAnswer[] | null | undefined
+): TSelection[] => {
+	if (!Array.isArray(savedAnswers)) return [];
+	return savedAnswers.map((answer) => ({
+		question_revision_id: answer.question_revision_id,
+		response: parseSavedResponse(answer.response),
+		visited: answer.visited ?? false,
+		time_spent: 0,
+		bookmarked: answer.bookmarked ?? false,
+		is_reviewed: false
+	}));
 };

--- a/src/lib/helpers/testSession.ts
+++ b/src/lib/helpers/testSession.ts
@@ -62,3 +62,21 @@ export const getInitialSelections = (
 	savedAnswers: TSavedAnswer[] | null | undefined
 ): TSelection[] =>
 	localSelections.length > 0 ? localSelections : mapSavedAnswersToSelections(savedAnswers);
+
+/**
+ * The question index a fresh page load should start on: the exact server-saved
+ * question if known (cross-device resume), else the first question of the
+ * locally stored page (which only remembers the page, not the exact question).
+ */
+export const resolveInitialQuestionIndex = (
+	savedRevisionId: number | null | undefined,
+	questionIds: number[],
+	perPage: number,
+	storedPage: number | null | undefined
+): number => {
+	if (savedRevisionId != null) {
+		const index = questionIds.indexOf(savedRevisionId);
+		if (index >= 0) return index;
+	}
+	return ((storedPage || 1) - 1) * perPage;
+};

--- a/src/lib/helpers/testSession.ts
+++ b/src/lib/helpers/testSession.ts
@@ -78,5 +78,8 @@ export const resolveInitialQuestionIndex = (
 		const index = questionIds.indexOf(savedRevisionId);
 		if (index >= 0) return index;
 	}
-	return ((storedPage || 1) - 1) * perPage;
+	// The stored page comes from localStorage, so a stale or edited value could
+	// point past the end of the test; keep the fallback inside the real range.
+	const fallback = ((storedPage || 1) - 1) * perPage;
+	return Math.min(Math.max(fallback, 0), Math.max(questionIds.length - 1, 0));
 };

--- a/src/lib/server/test.ts
+++ b/src/lib/server/test.ts
@@ -1,4 +1,5 @@
 import { BACKEND_URL } from '$env/static/private';
+import { normalizeFeedbackEntry, type TFeedbackEntry } from '$lib/helpers/feedbackHelpers';
 
 export type TState = {
 	id: number;
@@ -95,6 +96,39 @@ export const getTestQuestions = async (
 	const testQuestions = await response.json();
 
 	return testQuestions;
+};
+
+/**
+ * The answer review and question data a submitted result page needs.
+ *
+ * Needed by the submit action and by a plain reload of an already-submitted
+ * test, so both show the same page. Returns nulls rather than throwing: the
+ * result is still worth showing if the review payload cannot be fetched.
+ */
+export const getSubmittedResultExtras = async (
+	candidate_test_id: number,
+	candidate_uuid: string,
+	// The caller's event fetch, so this keeps using the same fetch the inline
+	// version did rather than silently switching to the global one.
+	eventFetch: typeof fetch = fetch
+): Promise<{ feedback: TFeedbackEntry[] | null; testQuestions: unknown | null }> => {
+	try {
+		const [feedbackResponse, testQuestions] = await Promise.all([
+			eventFetch(
+				`${BACKEND_URL}/candidate/${candidate_test_id}/review-feedback?candidate_uuid=${candidate_uuid}`,
+				{ method: 'GET', headers: { accept: 'application/json' } }
+			),
+			getTestQuestions(candidate_test_id, candidate_uuid)
+		]);
+
+		if (!feedbackResponse.ok) return { feedback: null, testQuestions };
+
+		const feedbackData = await feedbackResponse.json();
+		return { feedback: feedbackData.map(normalizeFeedbackEntry), testQuestions };
+	} catch (error) {
+		console.error('Error fetching feedback:', error);
+		return { feedback: null, testQuestions: null };
+	}
 };
 
 export const getTimeLeft = async (candidate_test_id: number, candidate_uuid: string) => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -221,4 +221,7 @@ export type TTestDetails = {
 	bookmark: boolean;
 	show_feedback_immediately: boolean;
 	show_feedback_on_completion: boolean;
+	// The org requires candidates to arrive from their student portal, so the
+	// landing page says so instead of offering a start it would have to reject.
+	blocks_anonymous_start?: boolean;
 };

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -25,6 +25,7 @@
 	"Time remaining for the test": "Time remaining for the test",
 	"Start Test": "Start Test",
 	"Resume Test": "Resume Test",
+	"Please open this test from your student portal.": "Please open this test from your student portal.",
 	"Answer all mandatory questions!": "Answer all mandatory questions!",
 	"Please make sure all mandatory questions are answered": "Please make sure all mandatory questions are answered",
 	"before proceeding to the next page": "before proceeding to the next page",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -16,7 +16,7 @@
 	"Test Instructions": "Test Instructions",
 	"Test duration": "Test duration",
 	"Total marks": "Total marks",
-	"By clicking \"Start Test,\" you confirm that you have read and understood all instructions.": "By clicking \"Start Test,\" you confirm that you have read and understood all instructions.",
+	"By clicking \"{action},\" you confirm that you have read and understood all instructions.": "By clicking \"{action},\" you confirm that you have read and understood all instructions.",
 	"General Instructions": "General Instructions",
 	"I have read and understood the instructions as given": "I have read and understood the instructions as given",
 	"Start": "Start",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -24,6 +24,7 @@
 	"Your test will begin shortly!": "Your test will begin shortly!",
 	"Time remaining for the test": "Time remaining for the test",
 	"Start Test": "Start Test",
+	"Resume Test": "Resume Test",
 	"Answer all mandatory questions!": "Answer all mandatory questions!",
 	"Please make sure all mandatory questions are answered": "Please make sure all mandatory questions are answered",
 	"before proceeding to the next page": "before proceeding to the next page",

--- a/src/locales/hi-IN.json
+++ b/src/locales/hi-IN.json
@@ -24,6 +24,7 @@
 	"Your test will begin shortly!": "आपकी परीक्षा जल्द ही शुरू होगी!",
 	"Time remaining for the test": "परीक्षा के लिए शेष समय",
 	"Start Test": "परीक्षा शुरू करें",
+	"Resume Test": "परीक्षा फिर से शुरू करें",
 	"Answer all mandatory questions!": "सभी अनिवार्य प्रश्नों के उत्तर दें!",
 	"Please make sure all mandatory questions are answered": "कृपया सुनिश्चित करें कि सभी अनिवार्य प्रश्नों के उत्तर दिए गए हैं।",
 	"before proceeding to the next page": "अगले पृष्ठ पर जाने से पहले",

--- a/src/locales/hi-IN.json
+++ b/src/locales/hi-IN.json
@@ -16,7 +16,7 @@
 	"Test Instructions": "परीक्षा के निर्देश",
 	"Test duration": "परीक्षा की अवधि",
 	"Total marks": "कुल अंक",
-	"By clicking \"Start Test,\" you confirm that you have read and understood all instructions.": "\"परीक्षा शुरू करें\" पर क्लिक करके, आप पुष्टि करते हैं कि आपने सभी निर्देश पढ़ और समझ लिए हैं।",
+	"By clicking \"{action},\" you confirm that you have read and understood all instructions.": "\"{action}\" पर क्लिक करके, आप पुष्टि करते हैं कि आपने सभी निर्देश पढ़ और समझ लिए हैं।",
 	"General Instructions": "सामान्य निर्देश",
 	"I have read and understood the instructions as given": "मैंने दिए गए निर्देशों को पढ़ और समझ लिया है।",
 	"Start": "शुरू करें",

--- a/src/locales/hi-IN.json
+++ b/src/locales/hi-IN.json
@@ -25,6 +25,7 @@
 	"Time remaining for the test": "परीक्षा के लिए शेष समय",
 	"Start Test": "परीक्षा शुरू करें",
 	"Resume Test": "परीक्षा फिर से शुरू करें",
+	"Please open this test from your student portal.": "कृपया इस परीक्षा को अपने छात्र पोर्टल से खोलें।",
 	"Answer all mandatory questions!": "सभी अनिवार्य प्रश्नों के उत्तर दें!",
 	"Please make sure all mandatory questions are answered": "कृपया सुनिश्चित करें कि सभी अनिवार्य प्रश्नों के उत्तर दिए गए हैं।",
 	"before proceeding to the next page": "अगले पृष्ठ पर जाने से पहले",

--- a/src/routes/test/[slug]/+page.server.ts
+++ b/src/routes/test/[slug]/+page.server.ts
@@ -1,7 +1,13 @@
 import { BACKEND_URL } from '$env/static/private';
 import { dev } from '$app/environment';
 import { getCandidate } from '$lib/helpers/getCandidate';
-import { getTestQuestions, getTimeLeft, getStates, type TState } from '$lib/server/test';
+import {
+	getSubmittedResultExtras,
+	getTestQuestions,
+	getTimeLeft,
+	getStates,
+	type TState
+} from '$lib/server/test';
 import { validateForm } from '$lib/components/form/validation';
 import type { TTestDetails } from '$lib/types';
 import { error, fail, redirect, type Cookies } from '@sveltejs/kit';
@@ -102,14 +108,28 @@ export const load: PageServerLoad = async ({ locals, cookies, url, fetch }) => {
 		} catch (error) {
 			console.error('Error fetching submitted result:', error);
 		}
+		// Reloading an already-submitted test must show the same page as the
+		// moment of submission, so fetch the review payload the result page needs
+		// instead of dropping "View All Answers" and the section breakdown.
+		let feedback = null;
+		let testQuestions = null;
+		if (result && (testData.show_feedback_on_completion || testData.question_sets?.length)) {
+			({ feedback, testQuestions } = await getSubmittedResultExtras(
+				candidate.candidate_test_id,
+				candidate.candidate_uuid,
+				fetch
+			));
+		}
+
 		return {
 			candidate,
 			testData,
 			submitted: true,
 			result,
+			feedback,
 			// null (not 0) so the layout TestTimer does not render / auto-submit.
 			timeLeft: null,
-			testQuestions: null,
+			testQuestions,
 			locations
 		};
 	}
@@ -307,43 +327,11 @@ export const actions = {
 				let testQuestions = null;
 
 				if (testData.show_feedback_on_completion || testData.question_sets?.length) {
-					try {
-						const [feedbackResponse, testQuestionsData] = await Promise.all([
-							fetch(
-								`${BACKEND_URL}/candidate/${candidate.candidate_test_id}/review-feedback?candidate_uuid=${candidate.candidate_uuid}`,
-								{ method: 'GET', headers: { accept: 'application/json' } }
-							),
-							getTestQuestions(candidate.candidate_test_id, candidate.candidate_uuid)
-						]);
-						testQuestions = testQuestionsData;
-						if (feedbackResponse.ok) {
-							const feedbackData = await feedbackResponse.json();
-							feedback = feedbackData.map(
-								(item: {
-									question_revision_id: number;
-									submitted_answer: string | null;
-									correct_answer: number[];
-								}) => {
-									let submitted: number[] | string = [];
-									if (item.submitted_answer) {
-										try {
-											const parsed = JSON.parse(item.submitted_answer);
-											submitted = Array.isArray(parsed) ? parsed : item.submitted_answer;
-										} catch {
-											submitted = item.submitted_answer;
-										}
-									}
-									return {
-										question_revision_id: item.question_revision_id,
-										submitted_answer: submitted,
-										correct_answer: item.correct_answer
-									};
-								}
-							);
-						}
-					} catch (error) {
-						console.error('Error fetching feedback:', error);
-					}
+					({ feedback, testQuestions } = await getSubmittedResultExtras(
+						candidate.candidate_test_id,
+						candidate.candidate_uuid,
+						fetch
+					));
 				}
 
 				// For external (portal) launches, keep the cookie and mark it

--- a/src/routes/test/[slug]/+page.server.ts
+++ b/src/routes/test/[slug]/+page.server.ts
@@ -27,23 +27,10 @@ function setCandidateCookie(cookies: Cookies, testLink: string, candidateData: u
 }
 
 function getExternalCandidateLaunch(url: URL) {
+	// The candidate uuid is all a launch needs: start_test creates or resolves
+	// the attempt for it and returns the candidate_test_id.
 	const candidateUuid = url.searchParams.get('candidate_uuid');
-	const candidateTestIdRaw = url.searchParams.get('candidate_test_id');
-
-	if (!candidateUuid && !candidateTestIdRaw) return null;
-	if (!candidateUuid || !candidateTestIdRaw) {
-		throw error(400, 'Invalid external candidate launch');
-	}
-
-	const candidateTestId = Number(candidateTestIdRaw);
-	if (!Number.isInteger(candidateTestId) || candidateTestId <= 0) {
-		throw error(400, 'Invalid external candidate launch');
-	}
-
-	return {
-		candidate_uuid: candidateUuid,
-		candidate_test_id: candidateTestId
-	};
+	return candidateUuid ? { candidate_uuid: candidateUuid } : null;
 }
 
 export const load: PageServerLoad = async ({ locals, cookies, url, fetch }) => {

--- a/src/routes/test/[slug]/+page.server.ts
+++ b/src/routes/test/[slug]/+page.server.ts
@@ -165,7 +165,11 @@ export const load: PageServerLoad = async ({ locals, cookies, url, fetch }) => {
 		locations,
 		// True for an external launch resuming an already-started attempt: the
 		// landing screen shows "Resume" and the pre-test form is skipped.
-		isResumed: candidate?.is_resumed === true
+		isResumed: candidate?.is_resumed === true,
+		// An external launch reaches the landing screen with the cookie already
+		// set, so it must not be treated as an anonymous visitor even though
+		// `candidate` is deliberately null here.
+		isExternalLaunch: candidate?.external_launch === true
 	};
 };
 

--- a/src/routes/test/[slug]/+page.server.ts
+++ b/src/routes/test/[slug]/+page.server.ts
@@ -75,7 +75,14 @@ export const load: PageServerLoad = async ({ locals, cookies, url, fetch }) => {
 		// screen so the candidate never re-enters the quiz.
 		const candidateData = startData.is_submitted
 			? { ...startData, external_launch: true, submitted: true }
-			: { ...startData, external_launch: true, pending_start: true };
+			: {
+					...startData,
+					external_launch: true,
+					pending_start: true,
+					// A resumed attempt already has its form response; the landing screen
+					// shows "Resume" and the form is skipped (see +page.svelte).
+					is_resumed: startData.is_resumed === true
+				};
 		setCandidateCookie(cookies, testData.link, candidateData);
 		throw redirect(303, '/test/' + testData.link);
 	}
@@ -168,7 +175,10 @@ export const load: PageServerLoad = async ({ locals, cookies, url, fetch }) => {
 		timeToBegin: locals.timeToBegin,
 		testData,
 		testQuestions: null,
-		locations
+		locations,
+		// True for an external launch resuming an already-started attempt: the
+		// landing screen shows "Resume" and the pre-test form is skipped.
+		isResumed: candidate?.is_resumed === true
 	};
 };
 

--- a/src/routes/test/[slug]/+page.svelte
+++ b/src/routes/test/[slug]/+page.svelte
@@ -35,6 +35,15 @@
 		showFeedbackView = false;
 	});
 
+	// Review is reachable straight after submitting (form data) and on a reload of
+	// an already-submitted test (load data), so take whichever is present.
+	const feedbackView = $derived.by(() => {
+		const candidate = form?.candidate ?? data.candidate;
+		const feedback = form?.feedback ?? data.feedback;
+		if (!candidate || !feedback) return null;
+		return { candidate, feedback, testQuestions: form?.testQuestions ?? data.testQuestions };
+	});
+
 	function handleViewFeedback() {
 		showFeedbackView = true;
 	}
@@ -50,11 +59,11 @@
 </script>
 
 <section>
-	{#if showFeedbackView && form?.feedback && form?.candidate}
+	{#if showFeedbackView && feedbackView}
 		<ViewFeedback
-			candidate={form.candidate}
-			feedback={form.feedback}
-			testQuestions={form.testQuestions}
+			candidate={feedbackView.candidate}
+			feedback={feedbackView.feedback}
+			testQuestions={feedbackView.testQuestions}
 			onBack={handleBackToResults}
 		/>
 	{:else if data.candidate === undefined}
@@ -69,7 +78,13 @@
 		/>
 	{:else if data.submitted}
 		{#if data.result}
-			<TestResult resultData={data.result} testDetails={data.testData} />
+			<TestResult
+				resultData={data.result}
+				testDetails={data.testData}
+				feedback={data.feedback}
+				testQuestions={data.testQuestions}
+				onViewFeedback={handleViewFeedback}
+			/>
 		{:else}
 			<p>{$t('You have already submitted this test.')}</p>
 		{/if}

--- a/src/routes/test/[slug]/+page.svelte
+++ b/src/routes/test/[slug]/+page.svelte
@@ -74,7 +74,12 @@
 			<p>{$t('You have already submitted this test.')}</p>
 		{/if}
 	{:else if !data.candidate && !showProfileForm}
-		<LandingPage testDetails={data.testData} isResumed={data.isResumed} bind:showProfileForm />
+		<LandingPage
+			testDetails={data.testData}
+			isResumed={data.isResumed}
+			isExternalLaunch={data.isExternalLaunch}
+			bind:showProfileForm
+		/>
 	{:else if !data.candidate && !data.isResumed && hasDynamicForm && !showOmrChoice && data.testData.form}
 		<DynamicForm
 			form={data.testData.form}

--- a/src/routes/test/[slug]/+page.svelte
+++ b/src/routes/test/[slug]/+page.svelte
@@ -74,15 +74,15 @@
 			<p>{$t('You have already submitted this test.')}</p>
 		{/if}
 	{:else if !data.candidate && !showProfileForm}
-		<LandingPage testDetails={data.testData} bind:showProfileForm />
-	{:else if !data.candidate && hasDynamicForm && !showOmrChoice && data.testData.form}
+		<LandingPage testDetails={data.testData} isResumed={data.isResumed} bind:showProfileForm />
+	{:else if !data.candidate && !data.isResumed && hasDynamicForm && !showOmrChoice && data.testData.form}
 		<DynamicForm
 			form={data.testData.form}
 			testDetails={data.testData}
 			locations={data.locations || {}}
 			onContinue={hasOmrChoice ? handleFormContinue : undefined}
 		/>
-	{:else if !data.candidate && hasOmrChoice}
+	{:else if !data.candidate && !data.isResumed && hasOmrChoice}
 		<CandidateProfile testDetails={data.testData} formResponses={candidateFormResponses} />
 	{:else if hasRenderableQuestions}
 		{#if data.testData?.omr !== 'NEVER' && (data.candidate.use_omr === 'true' || data.testData?.omr === 'ALWAYS')}

--- a/src/routes/test/[slug]/api/current-position/+server.ts
+++ b/src/routes/test/[slug]/api/current-position/+server.ts
@@ -1,0 +1,74 @@
+import { BACKEND_URL } from '$env/static/private';
+import { getCandidate } from '$lib/helpers/getCandidate';
+import type { TCandidate } from '$lib/types';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request, cookies }) => {
+	const cookieCandidate = getCandidate(cookies);
+	if (!cookieCandidate) {
+		return new Response(
+			JSON.stringify({ success: false, error: 'Session expired or test already submitted' }),
+			{ status: 401, headers: { 'Content-Type': 'application/json' } }
+		);
+	}
+
+	const {
+		question_revision_id,
+		candidate
+	}: {
+		question_revision_id: number;
+		candidate: TCandidate;
+	} = await request.json();
+
+	if (
+		cookieCandidate.candidate_test_id !== candidate?.candidate_test_id ||
+		cookieCandidate.candidate_uuid !== candidate?.candidate_uuid
+	) {
+		return new Response(JSON.stringify({ success: false, error: 'Session mismatch' }), {
+			status: 401,
+			headers: { 'Content-Type': 'application/json' }
+		});
+	}
+
+	if (!question_revision_id || !candidate?.candidate_test_id || !candidate?.candidate_uuid) {
+		return new Response(JSON.stringify({ success: false, error: 'Missing required fields' }), {
+			status: 400,
+			headers: { 'Content-Type': 'application/json' }
+		});
+	}
+
+	try {
+		const res = await fetch(
+			`${BACKEND_URL}/candidate/current_position/${candidate.candidate_test_id}?candidate_uuid=${candidate.candidate_uuid}`,
+			{
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ current_question_revision_id: question_revision_id })
+			}
+		);
+
+		if (!res.ok) {
+			let errorMessage = `Failed to save current position: ${res.status} ${res.statusText}`;
+
+			try {
+				const errorData = await res.json();
+				errorMessage = errorData?.detail || errorData?.message || errorData?.error || errorMessage;
+			} catch {}
+
+			return new Response(JSON.stringify({ success: false, error: errorMessage }), {
+				status: res.status,
+				headers: { 'Content-Type': 'application/json' }
+			});
+		}
+
+		return new Response(JSON.stringify({ success: true }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' }
+		});
+	} catch (error: any) {
+		return new Response(JSON.stringify({ success: false, error: error.message }), {
+			status: 500,
+			headers: { 'Content-Type': 'application/json' }
+		});
+	}
+};

--- a/src/routes/test/[slug]/api/current-position/+server.ts
+++ b/src/routes/test/[slug]/api/current-position/+server.ts
@@ -12,13 +12,16 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 		);
 	}
 
-	const {
-		question_revision_id,
-		candidate
-	}: {
-		question_revision_id: number;
-		candidate: TCandidate;
-	} = await request.json();
+	let body: { question_revision_id: number; candidate: TCandidate };
+	try {
+		body = await request.json();
+	} catch {
+		return new Response(JSON.stringify({ success: false, error: 'Invalid JSON body' }), {
+			status: 400,
+			headers: { 'Content-Type': 'application/json' }
+		});
+	}
+	const { question_revision_id, candidate } = body;
 
 	if (
 		cookieCandidate.candidate_test_id !== candidate?.candidate_test_id ||
@@ -43,7 +46,10 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 			{
 				method: 'PATCH',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ current_question_revision_id: question_revision_id })
+				body: JSON.stringify({ current_question_revision_id: question_revision_id }),
+				// Fires on every navigation, so a stalled backend must not keep the
+				// request (and the position it carries) hanging around.
+				signal: AbortSignal.timeout(10_000)
 			}
 		);
 

--- a/src/routes/test/[slug]/api/current-position/server.test.ts
+++ b/src/routes/test/[slug]/api/current-position/server.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createMockResponse, mockCandidate, createMockCookies } from '$lib/test-utils';
+import { getCandidate } from '$lib/helpers/getCandidate';
+import { POST } from './+server';
+
+// Mock the environment variable
+vi.mock('$env/static/private', () => ({
+	BACKEND_URL: 'http://test-backend.com'
+}));
+
+// Mock getCandidate
+vi.mock('$lib/helpers/getCandidate', () => ({
+	getCandidate: vi.fn()
+}));
+
+describe('POST /test/[slug]/api/current-position', () => {
+	beforeEach(() => {
+		vi.stubGlobal('fetch', vi.fn());
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	const createMockRequest = (body: any) => ({
+		json: () => Promise.resolve(body)
+	});
+
+	it('should patch the current position to the backend', async () => {
+		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
+		vi.mocked(fetch).mockResolvedValueOnce(
+			createMockResponse({ id: mockCandidate.candidate_test_id }) as unknown as Response
+		);
+
+		const mockCookies = createMockCookies();
+		const request = createMockRequest({
+			question_revision_id: 7,
+			candidate: mockCandidate
+		});
+		const response = await POST({ request, cookies: mockCookies } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.success).toBe(true);
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(fetch).toHaveBeenCalledWith(
+			`http://test-backend.com/candidate/current_position/${mockCandidate.candidate_test_id}?candidate_uuid=${mockCandidate.candidate_uuid}`,
+			expect.objectContaining({
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: expect.stringContaining('"current_question_revision_id":7')
+			})
+		);
+	});
+
+	it('should return 401 when cookie candidate is missing', async () => {
+		vi.mocked(getCandidate).mockReturnValue(null);
+
+		const mockCookies = createMockCookies();
+		const request = createMockRequest({ question_revision_id: 7, candidate: mockCandidate });
+		const response = await POST({ request, cookies: mockCookies } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(401);
+		expect(data.error).toBe('Session expired or test already submitted');
+	});
+
+	it('should return 401 when cookie candidate does not match request candidate', async () => {
+		vi.mocked(getCandidate).mockReturnValue({
+			candidate_uuid: 'different-uuid',
+			candidate_test_id: 999
+		});
+
+		const mockCookies = createMockCookies();
+		const request = createMockRequest({ question_revision_id: 7, candidate: mockCandidate });
+		const response = await POST({ request, cookies: mockCookies } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(401);
+		expect(data.error).toBe('Session mismatch');
+	});
+
+	it('should return 400 when question_revision_id is missing', async () => {
+		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
+
+		const mockCookies = createMockCookies();
+		const request = createMockRequest({ candidate: mockCandidate });
+		const response = await POST({ request, cookies: mockCookies } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(data.error).toBe('Missing required fields');
+	});
+
+	it('should preserve the backend detail when the position update is rejected', async () => {
+		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
+		vi.mocked(fetch).mockResolvedValueOnce(
+			createMockResponse(
+				{ detail: 'Test already submitted' },
+				{ ok: false, status: 400 }
+			) as unknown as Response
+		);
+
+		const mockCookies = createMockCookies();
+		const request = createMockRequest({ question_revision_id: 7, candidate: mockCandidate });
+		const response = await POST({ request, cookies: mockCookies } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(data.success).toBe(false);
+		expect(data.error).toBe('Test already submitted');
+	});
+
+	it('should return 500 when fetch throws', async () => {
+		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
+		vi.mocked(fetch).mockRejectedValueOnce(new Error('Connection refused'));
+
+		const mockCookies = createMockCookies();
+		const request = createMockRequest({ question_revision_id: 7, candidate: mockCandidate });
+		const response = await POST({ request, cookies: mockCookies } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(500);
+		expect(data.error).toBe('Connection refused');
+	});
+});

--- a/src/routes/test/[slug]/api/current-position/server.test.ts
+++ b/src/routes/test/[slug]/api/current-position/server.test.ts
@@ -54,6 +54,19 @@ describe('POST /test/[slug]/api/current-position', () => {
 		);
 	});
 
+	it('should return 400 when the body is not valid JSON', async () => {
+		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
+
+		const mockCookies = createMockCookies();
+		const request = { json: () => Promise.reject(new SyntaxError('bad json')) };
+		const response = await POST({ request, cookies: mockCookies } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(data.error).toBe('Invalid JSON body');
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
 	it('should return 401 when cookie candidate is missing', async () => {
 		vi.mocked(getCandidate).mockReturnValue(null);
 

--- a/src/routes/test/[slug]/page.server.test.ts
+++ b/src/routes/test/[slug]/page.server.test.ts
@@ -349,36 +349,6 @@ describe('Page Server - load function', () => {
 		);
 	});
 
-	it('should reject an invalid external launch', async () => {
-		const mockCookies = createMockCookies();
-
-		await expect(
-			load({
-				locals: { testData: mockTestData, timeToBegin: 300 },
-				cookies: mockCookies,
-				fetch: vi.fn(),
-				url: new URL(
-					`http://localhost/test/${mockTestData.link}?candidate_uuid=${mockCandidate.candidate_uuid}`
-				)
-			} as any)
-		).rejects.toMatchObject({ status: 400 });
-	});
-
-	it('should reject an external launch with a non-numeric candidate_test_id', async () => {
-		const mockCookies = createMockCookies();
-
-		await expect(
-			load({
-				locals: { testData: mockTestData, timeToBegin: 300 },
-				cookies: mockCookies,
-				fetch: vi.fn(),
-				url: new URL(
-					`http://localhost/test/${mockTestData.link}?candidate_uuid=${mockCandidate.candidate_uuid}&candidate_test_id=abc`
-				)
-			} as any)
-		).rejects.toMatchObject({ status: 400 });
-	});
-
 	it('should ignore external launch handling when no launch params are present', async () => {
 		vi.mocked(getCandidate).mockReturnValue(null);
 		const mockCookies = createMockCookies();

--- a/src/routes/test/[slug]/page.server.test.ts
+++ b/src/routes/test/[slug]/page.server.test.ts
@@ -6,7 +6,7 @@ import {
 	mockTestData
 } from '$lib/test-utils';
 import { getCandidate } from '$lib/helpers/getCandidate';
-import { getTestQuestions, getTimeLeft } from '$lib/server/test';
+import { getSubmittedResultExtras, getTestQuestions, getTimeLeft } from '$lib/server/test';
 import { load, actions } from './+page.server';
 
 // Mock environment variables
@@ -26,7 +26,8 @@ vi.mock('$lib/helpers/getCandidate', () => ({
 vi.mock('$lib/server/test', () => ({
 	getTestQuestions: vi.fn(),
 	getTimeLeft: vi.fn(),
-	getStates: vi.fn().mockResolvedValue([])
+	getStates: vi.fn().mockResolvedValue([]),
+	getSubmittedResultExtras: vi.fn()
 }));
 
 // Mock SvelteKit functions
@@ -50,6 +51,8 @@ describe('Page Server - load function', () => {
 	beforeEach(() => {
 		vi.stubGlobal('fetch', vi.fn());
 		vi.clearAllMocks();
+		// Tests that care about the review payload override this.
+		vi.mocked(getSubmittedResultExtras).mockResolvedValue({ feedback: null, testQuestions: null });
 	});
 
 	afterEach(() => {
@@ -679,37 +682,32 @@ describe('Page Server - submitTest action', () => {
 	beforeEach(() => {
 		vi.stubGlobal('fetch', vi.fn());
 		vi.clearAllMocks();
+		// Tests that care about the review payload override this.
+		vi.mocked(getSubmittedResultExtras).mockResolvedValue({ feedback: null, testQuestions: null });
 	});
 
 	afterEach(() => {
 		vi.unstubAllGlobals();
 	});
 
-	it('should submit test and return result with feedback and testQuestions', async () => {
+	it('should pass the review payload through to the result page', async () => {
 		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
 
 		const mockResult = { score: 85, passed: true };
-		const mockFeedbackData = [
-			{
-				question_revision_id: 1,
-				submitted_answer: '[102]',
-				correct_answer: [102]
-			},
-			{
-				question_revision_id: 2,
-				submitted_answer: '[201, 203]',
-				correct_answer: [201, 202]
-			}
-		];
 		const mockQuestionData = { question_revisions: [], question_pagination: 5 };
+		const mockFeedback = [
+			{ question_revision_id: 1, submitted_answer: [102], correct_answer: [102] }
+		];
 
-		vi.mocked(getTestQuestions).mockResolvedValue(mockQuestionData);
+		vi.mocked(getSubmittedResultExtras).mockResolvedValue({
+			feedback: mockFeedback,
+			testQuestions: mockQuestionData
+		});
 
 		const mockFetch = vi
 			.fn()
 			.mockResolvedValueOnce(createMockResponse({ success: true }, { status: 200 }))
-			.mockResolvedValueOnce(createMockResponse(mockResult))
-			.mockResolvedValueOnce(createMockResponse(mockFeedbackData));
+			.mockResolvedValueOnce(createMockResponse(mockResult));
 
 		const mockCookies = createMockCookies();
 
@@ -721,22 +719,12 @@ describe('Page Server - submitTest action', () => {
 
 		expect(result.submitTest).toBe(true);
 		expect(result.result).toEqual(mockResult);
-		expect(result.feedback).toEqual([
-			{
-				question_revision_id: 1,
-				submitted_answer: [102],
-				correct_answer: [102]
-			},
-			{
-				question_revision_id: 2,
-				submitted_answer: [201, 203],
-				correct_answer: [201, 202]
-			}
-		]);
+		expect(result.feedback).toEqual(mockFeedback);
 		expect(result.testQuestions).toEqual(mockQuestionData);
-		expect(getTestQuestions).toHaveBeenCalledWith(
+		expect(getSubmittedResultExtras).toHaveBeenCalledWith(
 			mockCandidate.candidate_test_id,
-			mockCandidate.candidate_uuid
+			mockCandidate.candidate_uuid,
+			mockFetch
 		);
 		expect(mockCookies.delete).toHaveBeenCalledWith('sashakt-candidate', expect.any(Object));
 	});
@@ -762,109 +750,6 @@ describe('Page Server - submitTest action', () => {
 		expect(result.submitTest).toBe(true);
 		expect(result.result).toEqual(mockResult);
 		expect(mockCookies.delete).not.toHaveBeenCalled();
-	});
-
-	it('should handle empty feedback from review-feedback API', async () => {
-		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
-
-		const mockResult = { score: 0, passed: false };
-		vi.mocked(getTestQuestions).mockResolvedValue({
-			question_revisions: [],
-			question_pagination: 5
-		});
-
-		const mockFetch = vi
-			.fn()
-			.mockResolvedValueOnce(createMockResponse({ success: true }, { status: 200 }))
-			.mockResolvedValueOnce(createMockResponse(mockResult))
-			.mockResolvedValueOnce(createMockResponse([]));
-
-		const mockCookies = createMockCookies();
-
-		const result = await actions.submitTest({
-			cookies: mockCookies,
-			fetch: mockFetch,
-			locals: { testData: mockTestData }
-		} as any);
-
-		expect(result.submitTest).toBe(true);
-		expect(result.feedback).toEqual([]);
-	});
-
-	it('should handle null submitted_answer in feedback', async () => {
-		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
-
-		const mockResult = { score: 0, passed: false };
-		const mockFeedbackData = [
-			{
-				question_revision_id: 1,
-				submitted_answer: null,
-				correct_answer: [102]
-			}
-		];
-		vi.mocked(getTestQuestions).mockResolvedValue({
-			question_revisions: [],
-			question_pagination: 5
-		});
-
-		const mockFetch = vi
-			.fn()
-			.mockResolvedValueOnce(createMockResponse({ success: true }, { status: 200 }))
-			.mockResolvedValueOnce(createMockResponse(mockResult))
-			.mockResolvedValueOnce(createMockResponse(mockFeedbackData));
-
-		const mockCookies = createMockCookies();
-
-		const result = await actions.submitTest({
-			cookies: mockCookies,
-			fetch: mockFetch,
-			locals: { testData: mockTestData }
-		} as any);
-
-		expect(result.feedback[0].submitted_answer).toEqual([]);
-		expect(result.feedback[0].correct_answer).toEqual([102]);
-	});
-
-	it('should handle subjective answer string in feedback without crashing', async () => {
-		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
-
-		const mockResult = { score: 85, passed: true };
-		const mockFeedbackData = [
-			{
-				question_revision_id: 1,
-				submitted_answer: '[102]',
-				correct_answer: [102]
-			},
-			{
-				question_revision_id: 4,
-				submitted_answer: 'This is a subjective text answer',
-				correct_answer: []
-			}
-		];
-		vi.mocked(getTestQuestions).mockResolvedValue({
-			question_revisions: [],
-			question_pagination: 5
-		});
-
-		const mockFetch = vi
-			.fn()
-			.mockResolvedValueOnce(createMockResponse({ success: true }, { status: 200 }))
-			.mockResolvedValueOnce(createMockResponse(mockResult))
-			.mockResolvedValueOnce(createMockResponse(mockFeedbackData));
-
-		const mockCookies = createMockCookies();
-
-		const result = await actions.submitTest({
-			cookies: mockCookies,
-			fetch: mockFetch,
-			locals: { testData: mockTestData }
-		} as any);
-
-		expect(result.submitTest).toBe(true);
-		expect(result.feedback).toHaveLength(2);
-		expect(result.feedback[0].submitted_answer).toEqual([102]);
-		expect(result.feedback[1].submitted_answer).toEqual('This is a subjective text answer');
-		expect(result.feedback[1].correct_answer).toEqual([]);
 	});
 
 	it('should not fetch feedback when show_feedback_on_completion is false', async () => {

--- a/src/routes/test/[slug]/page.server.test.ts
+++ b/src/routes/test/[slug]/page.server.test.ts
@@ -281,11 +281,41 @@ describe('Page Server - load function', () => {
 		);
 		expect(mockCookies.set).toHaveBeenCalledWith(
 			'sashakt-candidate',
-			JSON.stringify({ ...mockCandidate, external_launch: true, pending_start: true }),
+			JSON.stringify({
+				...mockCandidate,
+				external_launch: true,
+				pending_start: true,
+				is_resumed: false
+			}),
 			expect.objectContaining({
 				path: `/test/${mockTestData.link}`,
 				httpOnly: true
 			})
+		);
+	});
+
+	it('marks the cookie is_resumed when the launch resolves a started attempt', async () => {
+		vi.mocked(getCandidate).mockReturnValue(null);
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(await createMockResponse({ ...mockCandidate, is_resumed: true }));
+		const mockCookies = createMockCookies();
+
+		await expect(
+			load({
+				locals: { testData: mockTestData, timeToBegin: 300 },
+				cookies: mockCookies,
+				fetch: mockFetch,
+				url: new URL(
+					`http://localhost/test/${mockTestData.link}?candidate_uuid=${mockCandidate.candidate_uuid}&candidate_test_id=${mockCandidate.candidate_test_id}`
+				)
+			} as any)
+		).rejects.toMatchObject({ status: 303, location: `/test/${mockTestData.link}` });
+
+		expect(mockCookies.set).toHaveBeenCalledWith(
+			'sashakt-candidate',
+			expect.stringContaining('"is_resumed":true'),
+			expect.objectContaining({ path: `/test/${mockTestData.link}`, httpOnly: true })
 		);
 	});
 


### PR DESCRIPTION
## Summary
Companion to sashakt-core #544 (issue #528). Makes an in-progress test resume on another device — landing on the **current question** *and* restoring the **answers**, in both the per-question and OMR views. Reads the position + answers from the server, not localStorage, so it works on a device that has never seen the attempt.

Also addresses the two follow-ups from @kurund's review: the landing screen now reads **"Resume Test"**, and the **pre-test form is skipped** when the candidate already completed it.

## The cross-device flow
1. Student starts the test from the Avanti portal on **device A**. That first start is what creates the attempt; answers and navigation record their position as they go.
2. Student opens **device B** and logs into the portal again with the same id → `start_test` resolves the same attempt and reports `is_resumed` (core #574).
3. Device B has no local cache, so it seeds the page from `candidate_test.current_question_revision_id` and the answers from `saved_answers` → **resumes on the exact question, answers intact**, showing "Resume Test" and no form.

The server is the source of truth on a fresh device; localStorage is only a same-device fast path.

## Changes
- `Question.svelte`: pick the initial page from `current_question_revision_id` (falling back to the stored page); seed answers from `saved_answers` when this device has no local cache; sync the position on navigation.
- `OmrSheet.svelte`: also seeds answers from the server on load (previously OMR answers were lost on a fresh device, since it only read localStorage).
- `LandingPage.svelte`: on a resume, show **"Resume Test"** and start the attempt directly instead of routing through the form/OMR choice. The confirmation line uses the same wording as the button.
- `+page.svelte` / `+page.server.ts`: carry `is_resumed` from the launch response through the candidate cookie, and skip the pre-test form and OMR choice on a resume.
- Add `/test/[slug]/api/current-position` proxy that PATCHes `…/candidate/current_position/…` (mirrors `submit-answer`).
- Add `mapSavedAnswersToSelections` / `getInitialSelections` helpers (pure, unit-tested) shared by both views; reviewed answers restore their `is_reviewed` + (already-seen) `correct_answer` so they stay locked.
- Take only `candidate_uuid` off the launch URL. Provisioning no longer pre-creates the attempt, so `candidate_test_id` is gone from the URL and its parse/validate branch (and the two tests that only covered it) go with it.

### Review fixes on the position path
Four points raised on this PR, all in the same code:
- `resolveInitialQuestionIndex` is clamped to the real question range — the fallback reads a page number out of localStorage, so a stale value could land the candidate on a question that does not exist.
- The proxy parses the body inside a `try`, so a malformed body is a 400 instead of an unhandled 500.
- The backend PATCH gets a 10s timeout; it fires on every navigation.
- `syncCurrentPosition` checks `response.ok` — `fetch` only rejects on network failure, so a 4xx/5xx was treated as a successful save and would silently leave the resume position stale.

## Tested (automated)
- `pnpm vitest run` — **1133 passed (47 files)**. Covers the current-position proxy, the cookie carrying `is_resumed`, `mapSavedAnswersToSelections`, `getInitialSelections`, OMR + per-question render, plus the clamp and bad-JSON cases from the review fixes above.

## Manual testing (browser, local stack, test with a pre-test form)
1. Fresh id → **"Start Test"** → the form is shown → fill it → the first question opens.
2. Close the tab.
3. Log in again with the same id → **"Resume Test"**, **no form** → continues on the saved question.

Because the attempt row is created by the first start rather than at provision time, "an attempt exists" now means "the candidate started" — so the resume signal no longer needs to infer intent from a saved position or an answer.

## Depends on
- sashakt-core #544 (`current_question_revision_id`, `current_position`, `saved_answers`) — merged.
- sashakt-core #573 (provision creates only the candidate; launch URL drops `candidate_test_id`) — **required**, the launch URL shape changes here.
- sashakt-core #574 (`is_resumed`) — for the relabel and form-skip.
- portal-backend `feat/sashakt-access` builds the launch URL with only `candidate_uuid`.
