### PR TITLE
Refactoring Timer Logic to avoid Multiple Instances of Timer

### DIFF
--- a/src/lib/components/TestTimer.svelte
+++ b/src/lib/components/TestTimer.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
-	import { page } from '$app/state';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Spinner } from '$lib/components/ui/spinner';
 	import { createFormEnhanceHandler } from '$lib/helpers/formErrorHandler';
+	import { testTimerState } from '$lib/testTimerState.svelte';
 	import type { TCandidate } from '$lib/types';
 	import { Clock } from '@lucide/svelte';
 	import { t } from 'svelte-i18n';
@@ -20,134 +20,27 @@
 		pauseTimerWhenInactive?: boolean;
 	} = $props();
 
-	const HEARTBEAT_INTERVAL_MS = 15000;
-
-	let formElement = $state<HTMLFormElement>();
-	let timeLeft = $state(initialTime);
-	let open = $state(false);
-	let isSubmitting = $state(false);
-	let submitError = $state<string | null>(null);
-	let countdownInterval: ReturnType<typeof setInterval> | null = null;
-	let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
-	let submitTimeout: ReturnType<typeof setTimeout> | null = null;
-	let hasTriggeredAutoSubmit = $state(false);
-	let nextSyncRequestId = 0;
-	let latestAppliedSyncRequestId = 0;
-
-	const clearCountdownInterval = () => {
-		if (countdownInterval) {
-			clearInterval(countdownInterval);
-			countdownInterval = null;
-		}
-	};
-
-	const clearHeartbeatInterval = () => {
-		if (heartbeatInterval) {
-			clearInterval(heartbeatInterval);
-			heartbeatInterval = null;
-		}
-	};
-
-	const clearSubmitTimeout = () => {
-		if (submitTimeout) {
-			clearTimeout(submitTimeout);
-			submitTimeout = null;
-		}
-	};
-
-	const triggerAutoSubmit = () => {
-		if (hasTriggeredAutoSubmit) return;
-		hasTriggeredAutoSubmit = true;
-		clearSubmitTimeout();
-		submitTimeout = setTimeout(() => {
-			formElement?.requestSubmit();
-		}, 5000);
-	};
-
-	const handleTimeUp = () => {
-		timeLeft = 0;
-		open = true;
-		clearCountdownInterval();
-		clearHeartbeatInterval();
-		triggerAutoSubmit();
-	};
-
-	const updateTimeLeft = (nextTimeLeft: number) => {
-		timeLeft = Math.max(nextTimeLeft, 0);
-		if (timeLeft === 10 * 60) open = true;
-		if (timeLeft === 0) handleTimeUp();
-	};
-
-	const startCountdown = () => {
-		clearCountdownInterval();
-		countdownInterval = setInterval(() => {
-			if (timeLeft === 10 * 60) open = true;
-			if (timeLeft <= 1) {
-				handleTimeUp();
-			} else {
-				timeLeft--;
-			}
-		}, 1000);
-	};
-
-	const syncTimer = async (event: 'resume' | 'heartbeat') => {
-		if (!pauseTimerWhenInactive || !candidate) return;
-
-		const requestId = ++nextSyncRequestId;
-
-		try {
-			const response = await fetch(`/test/${page.params.slug}/api/timer`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ candidate, event })
-			});
-
-			if (!response.ok) return;
-
-			const data = await response.json();
-			if (typeof data.time_left !== 'number') return;
-			if (requestId < latestAppliedSyncRequestId) return;
-
-			latestAppliedSyncRequestId = requestId;
-			updateTimeLeft(Math.min(timeLeft, data.time_left));
-		} catch {}
-	};
-
-	const startHeartbeat = () => {
-		if (!pauseTimerWhenInactive || !candidate || heartbeatInterval) return;
-
-		heartbeatInterval = setInterval(() => {
-			void syncTimer('heartbeat');
-		}, HEARTBEAT_INTERVAL_MS);
-	};
-
-	const resumeTimer = () => {
-		startCountdown();
-		startHeartbeat();
-		void syncTimer('resume');
-	};
+	// TestTimer can be mounted more than once at a time (one instance per
+	// responsive nav layout). Only the "owner" instance drives the countdown,
+	// heartbeat sync, and dialog — everyone else just displays the shared
+	// timeLeft, so there's never more than one "time left" popup.
+	const instanceId = Symbol();
 
 	onMount(() => {
-		if (!pauseTimerWhenInactive) {
-			startCountdown();
-			return () => {
-				clearHeartbeatInterval();
-				clearCountdownInterval();
-				clearSubmitTimeout();
-			};
-		}
+		testTimerState.register(instanceId, initialTime, candidate, pauseTimerWhenInactive);
+		return () => testTimerState.unregister(instanceId);
+	});
 
-		resumeTimer();
+	const isOwner = $derived(testTimerState.ownerId === instanceId);
 
-		return () => {
-			clearCountdownInterval();
-			clearHeartbeatInterval();
-			clearSubmitTimeout();
-		};
+	$effect(() => {
+		if (!isOwner) return;
+		testTimerState.startForOwner();
+		return () => testTimerState.stopForOwner();
 	});
 
 	const lessTime = () => {
-		return timeLeft <= 10 * 60;
+		return testTimerState.timeLeft <= 10 * 60;
 	};
 
 	const formatTime = (seconds: number) => {
@@ -163,9 +56,9 @@
 
 	// enhance handler for auto-submit form action
 	const handleSubmitTestEnhance = createFormEnhanceHandler({
-		setLoading: (loading) => (isSubmitting = loading),
-		setError: (error) => (submitError = error),
-		setDialogOpen: (openState) => (open = openState)
+		setLoading: (loading) => (testTimerState.isSubmitting = loading),
+		setError: (error) => (testTimerState.submitError = error),
+		setDialogOpen: (openState) => (testTimerState.open = openState)
 	});
 </script>
 
@@ -173,69 +66,71 @@
 	class={`inline-flex items-center gap-x-1 rounded-full ${lessTime() ? 'bg-error-subtle text-error' : 'bg-success-subtle text-success'} px-2 py-1.5 text-sm font-medium`}
 >
 	<Clock size={18} />
-	{formatTime(timeLeft)}
+	{formatTime(testTimerState.timeLeft)}
 
-	<Dialog.Root bind:open>
-		{#if timeLeft <= 10 * 60 && timeLeft}
-			<Dialog.Content class="gap-0 overflow-hidden p-0 sm:max-w-100">
-				<div class="bg-muted px-6 pt-6 pr-12 pb-4">
-					<Dialog.Title class="text-base font-semibold">{$t('10 mins left!')}</Dialog.Title>
-				</div>
+	{#if isOwner}
+		<Dialog.Root bind:open={testTimerState.open}>
+			{#if testTimerState.timeLeft <= 10 * 60 && testTimerState.timeLeft}
+				<Dialog.Content class="gap-0 overflow-hidden p-0 sm:max-w-100">
+					<div class="bg-muted px-6 pt-6 pr-12 pb-4">
+						<Dialog.Title class="text-base font-semibold">{$t('10 mins left!')}</Dialog.Title>
+					</div>
 
-				<div class="border-border border-t"></div>
+					<div class="border-border border-t"></div>
 
-				<div class="bg-card px-6 py-6">
-					<Dialog.Description>
-						<p class="text-muted-foreground text-sm">
-							{$t('Please note that there is only 10 mins left for the test to complete, hurry up!')}
-						</p>
-					</Dialog.Description>
-				</div>
+					<div class="bg-card px-6 py-6">
+						<Dialog.Description>
+							<p class="text-muted-foreground text-sm">
+								{$t('Please note that there is only 10 mins left for the test to complete, hurry up!')}
+							</p>
+						</Dialog.Description>
+					</div>
 
-				<div class="bg-card flex justify-end px-6 pb-6">
-					<Dialog.Close><Button>{$t('Okay')}</Button></Dialog.Close>
-				</div>
-			</Dialog.Content>
-		{:else}
-			<Dialog.Content
-				class="w-80 rounded-xl text-center [&>button]:hidden"
-				interactOutsideBehavior="ignore"
-				escapeKeydownBehavior="ignore"
-			>
-				<Dialog.Title>
-					{#if submitError}
-						{$t('Submission Failed')}
-					{:else}
-						{$t('Time Up!')}
-					{/if}
-				</Dialog.Title>
-				<Dialog.Description>
-					{#if submitError}
-						<div class="text-destructive">
-							<p class="mb-2">{submitError}</p>
-							<p class="text-muted-foreground">{$t('Please click Submit again to retry.')}</p>
-						</div>
-					{:else}
-						{$t('The test has ended.')}
-					{/if}
-				</Dialog.Description>
-
-				<form
-					action="?/submitTest"
-					method="POST"
-					use:enhance={handleSubmitTestEnhance}
-					bind:this={formElement}
+					<div class="bg-card flex justify-end px-6 pb-6">
+						<Dialog.Close><Button>{$t('Okay')}</Button></Dialog.Close>
+					</div>
+				</Dialog.Content>
+			{:else}
+				<Dialog.Content
+					class="w-80 rounded-xl text-center [&>button]:hidden"
+					interactOutsideBehavior="ignore"
+					escapeKeydownBehavior="ignore"
 				>
-					{#if timeLeft > 0 || submitError}
-						<Button type="submit" class="w-32" disabled={isSubmitting}>
-							{#if isSubmitting}
-								<Spinner />
-							{/if}
-							{$t('Submit')}
-						</Button>
-					{/if}
-				</form>
-			</Dialog.Content>
-		{/if}
-	</Dialog.Root>
+					<Dialog.Title>
+						{#if testTimerState.submitError}
+							{$t('Submission Failed')}
+						{:else}
+							{$t('Time Up!')}
+						{/if}
+					</Dialog.Title>
+					<Dialog.Description>
+						{#if testTimerState.submitError}
+							<div class="text-destructive">
+								<p class="mb-2">{testTimerState.submitError}</p>
+								<p class="text-muted-foreground">{$t('Please click Submit again to retry.')}</p>
+							</div>
+						{:else}
+							{$t('The test has ended.')}
+						{/if}
+					</Dialog.Description>
+
+					<form
+						action="?/submitTest"
+						method="POST"
+						use:enhance={handleSubmitTestEnhance}
+						bind:this={testTimerState.formElement}
+					>
+						{#if testTimerState.timeLeft > 0 || testTimerState.submitError}
+							<Button type="submit" class="w-32" disabled={testTimerState.isSubmitting}>
+								{#if testTimerState.isSubmitting}
+									<Spinner />
+								{/if}
+								{$t('Submit')}
+							</Button>
+						{/if}
+					</form>
+				</Dialog.Content>
+			{/if}
+		</Dialog.Root>
+	{/if}
 </div>

--- a/src/lib/components/TestTimer.svelte.test.ts
+++ b/src/lib/components/TestTimer.svelte.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { createMockResponse, mockCandidate } from '$lib/test-utils';
+import { testTimerState } from '$lib/testTimerState.svelte';
 import TestTimer from './TestTimer.svelte';
 
 // Mock SvelteKit modules
@@ -26,6 +27,7 @@ describe('TestTimer', () => {
 		vi.useRealTimers();
 		vi.unstubAllGlobals();
 		vi.clearAllMocks();
+		testTimerState.resetForTests();
 	});
 
 	it('should render time in HH:MM:SS format', () => {
@@ -321,6 +323,72 @@ describe('TestTimer', () => {
 			await waitFor(() => {
 				expect(screen.queryByText('10 mins left!')).not.toBeInTheDocument();
 			});
+		});
+
+		it('does not reopen after being dismissed when a resume sync and the countdown tick detect the same threshold independently', async () => {
+			// Both a resume sync response and the countdown's own first tick
+			// can independently notice timeLeft === 600; without a one-time
+			// latch, dismissing the dialog after the first detection gets
+			// reopened moments later by the second one.
+			vi.mocked(fetch).mockResolvedValue(
+				createMockResponse({ time_left: 600 }) as unknown as Response
+			);
+
+			render(TestTimer, {
+				props: { timeLeft: 600, candidate: mockCandidate, pauseTimerWhenInactive: true }
+			});
+
+			// let the resume sync resolve and open the dialog
+			await vi.waitFor(() => {
+				expect(screen.getByText('10 mins left!')).toBeInTheDocument();
+			});
+
+			const okayButtons = screen.getAllByRole('button', { name: /okay/i });
+			okayButtons[0].click();
+			await waitFor(() => {
+				expect(screen.queryByText('10 mins left!')).not.toBeInTheDocument();
+			});
+
+			// the countdown's own first tick also observes timeLeft === 600
+			// at this point; it must not reopen the dialog
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(screen.queryByText('10 mins left!')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('multiple simultaneous instances', () => {
+		// Regression coverage for the layout mounting one TestTimer per
+		// responsive breakpoint (mobile + desktop) at the same time.
+		it('shows only one 10-minute warning dialog when two instances are mounted', async () => {
+			render(TestTimer, { props: { timeLeft: 601 } });
+			render(TestTimer, { props: { timeLeft: 601 } });
+
+			await vi.advanceTimersByTimeAsync(2000);
+
+			expect(screen.getAllByText('10 mins left!')).toHaveLength(1);
+		});
+
+		it('keeps both instances displaying the same countdown', async () => {
+			render(TestTimer, { props: { timeLeft: 10 } });
+			render(TestTimer, { props: { timeLeft: 10 } });
+
+			expect(screen.getAllByText('00:00:10')).toHaveLength(2);
+
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(screen.getAllByText('00:00:09')).toHaveLength(2);
+		});
+
+		it('keeps the countdown running after the owning instance unmounts', async () => {
+			const first = render(TestTimer, { props: { timeLeft: 10 } });
+			render(TestTimer, { props: { timeLeft: 10 } });
+
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(screen.getAllByText('00:00:09')).toHaveLength(2);
+
+			first.unmount();
+
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(screen.getByText('00:00:08')).toBeInTheDocument();
 		});
 	});
 });

--- a/src/lib/testTimerState.svelte.ts
+++ b/src/lib/testTimerState.svelte.ts
@@ -1,0 +1,216 @@
+import { page } from '$app/state';
+import type { TCandidate } from '$lib/types';
+
+const HEARTBEAT_INTERVAL_MS = 15000;
+const TEN_MINUTES_IN_SECONDS = 10 * 60;
+
+/**
+ * Shared countdown/dialog state for the test timer. TestTimer.svelte may be
+ * mounted more than once at a time (e.g. one instance per responsive nav
+ * layout); this singleton ensures the countdown, heartbeat sync, and the
+ * "time left" dialog only ever run once regardless of how many TestTimer
+ * instances are mounted.
+ */
+class TestTimerState {
+	timeLeft = $state(0);
+	open = $state(false);
+	isSubmitting = $state(false);
+	submitError = $state<string | null>(null);
+	formElement = $state<HTMLFormElement>();
+
+	// Public so instances can read it via a plain $derived (a pure read never
+	// causes the "effect reads and writes the same state" loop). All writes to
+	// ownerId happen here, from register()/unregister() — plain imperative
+	// calls from onMount, never from inside a reactive $effect.
+	ownerId = $state<symbol | null>(null);
+
+	private registeredInstances = new Set<symbol>();
+	private candidate: TCandidate | null = null;
+	private pauseTimerWhenInactive = false;
+	private hasTriggeredAutoSubmit = false;
+	// Both the countdown tick and a resume/heartbeat sync response can detect
+	// the same "crossed 10 minutes" event independently (one on a 1s timer,
+	// the other whenever its network request resolves). Without this latch,
+	// closing the dialog after the first detection gets reopened moments
+	// later by the second one.
+	private hasShownTenMinuteWarning = false;
+	private countdownInterval: ReturnType<typeof setInterval> | null = null;
+	private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+	private submitTimeout: ReturnType<typeof setTimeout> | null = null;
+	private nextSyncRequestId = 0;
+	private latestAppliedSyncRequestId = 0;
+
+	register(
+		instanceId: symbol,
+		initialTime: number,
+		candidate: TCandidate | null,
+		pauseTimerWhenInactive: boolean
+	) {
+		// only the first instance to register seeds the shared state; later
+		// instances mounting alongside it (e.g. the other responsive layout)
+		// must not stomp on a countdown that's already ticking.
+		if (this.registeredInstances.size === 0) {
+			this.timeLeft = initialTime;
+			this.candidate = candidate;
+			this.pauseTimerWhenInactive = pauseTimerWhenInactive;
+		}
+
+		this.registeredInstances.add(instanceId);
+		if (this.ownerId === null) {
+			this.ownerId = instanceId;
+		}
+	}
+
+	unregister(instanceId: symbol) {
+		this.registeredInstances.delete(instanceId);
+
+		if (this.ownerId === instanceId) {
+			const [nextOwner] = this.registeredInstances;
+			this.ownerId = nextOwner ?? null;
+		}
+
+		if (this.registeredInstances.size === 0) {
+			this.reset();
+		}
+	}
+
+	/** Test-only escape hatch: force back to a clean slate between test cases. */
+	resetForTests() {
+		this.registeredInstances.clear();
+		this.ownerId = null;
+		this.reset();
+	}
+
+	startForOwner() {
+		if (!this.pauseTimerWhenInactive) {
+			this.startCountdown();
+			return;
+		}
+		this.resumeTimer();
+	}
+
+	stopForOwner() {
+		this.clearCountdownInterval();
+		this.clearHeartbeatInterval();
+	}
+
+	private reset() {
+		this.stopForOwner();
+		this.clearSubmitTimeout();
+		this.timeLeft = 0;
+		this.open = false;
+		this.isSubmitting = false;
+		this.submitError = null;
+		this.formElement = undefined;
+		this.candidate = null;
+		this.pauseTimerWhenInactive = false;
+		this.hasTriggeredAutoSubmit = false;
+		this.hasShownTenMinuteWarning = false;
+		this.nextSyncRequestId = 0;
+		this.latestAppliedSyncRequestId = 0;
+	}
+
+	private clearCountdownInterval() {
+		if (this.countdownInterval) {
+			clearInterval(this.countdownInterval);
+			this.countdownInterval = null;
+		}
+	}
+
+	private clearHeartbeatInterval() {
+		if (this.heartbeatInterval) {
+			clearInterval(this.heartbeatInterval);
+			this.heartbeatInterval = null;
+		}
+	}
+
+	private clearSubmitTimeout() {
+		if (this.submitTimeout) {
+			clearTimeout(this.submitTimeout);
+			this.submitTimeout = null;
+		}
+	}
+
+	private triggerAutoSubmit() {
+		if (this.hasTriggeredAutoSubmit) return;
+		this.hasTriggeredAutoSubmit = true;
+		this.clearSubmitTimeout();
+		this.submitTimeout = setTimeout(() => {
+			this.formElement?.requestSubmit();
+		}, 5000);
+	}
+
+	private handleTimeUp() {
+		this.timeLeft = 0;
+		this.open = true;
+		this.clearCountdownInterval();
+		this.clearHeartbeatInterval();
+		this.triggerAutoSubmit();
+	}
+
+	private maybeShowTenMinuteWarning() {
+		if (this.hasShownTenMinuteWarning) return;
+		if (this.timeLeft !== TEN_MINUTES_IN_SECONDS) return;
+		this.hasShownTenMinuteWarning = true;
+		this.open = true;
+	}
+
+	private updateTimeLeft(nextTimeLeft: number) {
+		this.timeLeft = Math.max(nextTimeLeft, 0);
+		this.maybeShowTenMinuteWarning();
+		if (this.timeLeft === 0) this.handleTimeUp();
+	}
+
+	private startCountdown() {
+		this.clearCountdownInterval();
+		this.countdownInterval = setInterval(() => {
+			this.maybeShowTenMinuteWarning();
+			if (this.timeLeft <= 1) {
+				this.handleTimeUp();
+			} else {
+				this.timeLeft--;
+			}
+		}, 1000);
+	}
+
+	private async syncTimer(event: 'resume' | 'heartbeat') {
+		if (!this.pauseTimerWhenInactive || !this.candidate) return;
+
+		const requestId = ++this.nextSyncRequestId;
+
+		try {
+			const response = await fetch(`/test/${page.params.slug}/api/timer`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ candidate: this.candidate, event })
+			});
+
+			if (!response.ok) return;
+
+			const data = await response.json();
+			if (typeof data.time_left !== 'number') return;
+			if (requestId < this.latestAppliedSyncRequestId) return;
+
+			this.latestAppliedSyncRequestId = requestId;
+			this.updateTimeLeft(Math.min(this.timeLeft, data.time_left));
+		} catch {
+			// keep the local countdown running if the sync request fails
+		}
+	}
+
+	private startHeartbeat() {
+		if (!this.pauseTimerWhenInactive || !this.candidate || this.heartbeatInterval) return;
+
+		this.heartbeatInterval = setInterval(() => {
+			void this.syncTimer('heartbeat');
+		}, HEARTBEAT_INTERVAL_MS);
+	}
+
+	private resumeTimer() {
+		this.startCountdown();
+		this.startHeartbeat();
+		void this.syncTimer('resume');
+	}
+}
+
+export const testTimerState = new TestTimerState();


### PR DESCRIPTION
Fixes #256
The '10 minute left' dialog box appears multiple times  due to multiple instances of TestTimer Component. The current fix ensures that such  multiple  instances of TestTimer has a singleton structure underneath.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test timer now stays in sync across multiple open instances, so everyone sees the same countdown and warning state.
  * The ten-minute warning and time-up flow are now handled consistently across the UI.

* **Bug Fixes**
  * Fixed an issue where the warning dialog could reopen after being dismissed.
  * Improved countdown reliability so it continues correctly even if one timer view is closed.
  * Submission and auto-submit behavior now remain stable with shared timer state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->