### PR TITLE
Display External Identifier on Result Page

### DIFF
--- a/src/lib/components/TestResult.svelte
+++ b/src/lib/components/TestResult.svelte
@@ -144,9 +144,9 @@
 			<h2 class="text-foreground mb-1 text-lg font-bold">
 				"{testDetails.name}" {$t('Submitted')}
 			</h2>
-			{#if resultData?.external_user_id}
+			{#if resultData?.external_identifier}
 				<p class="text-muted-foreground mb-1 text-sm">
-					{$t('User ID')}: {resultData.external_user_id}
+					{$t('User ID')}: {resultData.external_identifier}
 				</p>
 			{/if}
 			<p class="text-muted-foreground mb-4 text-sm">

--- a/src/lib/components/TestResult.svelte.test.ts
+++ b/src/lib/components/TestResult.svelte.test.ts
@@ -92,6 +92,28 @@ describe('TestResult', () => {
 		expect(screen.queryByText('Unanswered')).not.toBeInTheDocument();
 	});
 
+	it('should display external identifier when present', () => {
+		render(TestResult, {
+			props: {
+				resultData: { ...mockResultData, external_identifier: '123456' },
+				testDetails: mockTestData
+			}
+		});
+
+		expect(screen.getByText('User ID: 123456')).toBeInTheDocument();
+	});
+
+	it('should not display external identifier when absent', () => {
+		render(TestResult, {
+			props: {
+				resultData: mockResultData,
+				testDetails: mockTestData
+			}
+		});
+
+		expect(screen.queryByText(/User ID:/)).not.toBeInTheDocument();
+	});
+
 	it('should display custom completion message when provided', () => {
 		const testDetailsWithMessage = {
 			...mockTestData,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -192,7 +192,7 @@ export type TResultData = {
 	marks_maximum: number | null;
 	total_questions: number;
 	certificate_download_url?: string;
-	external_user_id?: string | null;
+	external_identifier?: string | null;
 };
 
 export type TFeedback = {


### PR DESCRIPTION
Fixes #271 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test results now display the submitted user’s external identifier correctly.
  * The identifier is hidden when no value is available.

* **Tests**
  * Added coverage for displaying and omitting the external identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->