### PR TITLE
Display Section Banner above Question on Default Page Land

### DIFF
--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -129,9 +129,13 @@
 	}
 
 	// scroll a specific question into view after the page renders
+	// prefer the section banner (if this question starts a section) so it
+	// isn't left hidden above the fold
 	function scrollToQuestion(questionIndex: number) {
 		setTimeout(() => {
-			const element = document.getElementById(`question-${questionIndex}`);
+			const element =
+				document.getElementById(`question-${questionIndex}-banner`) ??
+				document.getElementById(`question-${questionIndex}`);
 			if (element) {
 				const offset = 120; // account for top banner and padding
 				const elementPosition = element.getBoundingClientRect().top + window.scrollY;
@@ -245,7 +249,10 @@
 							{@const absoluteIndex = (currentPage - 1) * perPage + index}
 							{@const section = sectionByQuestionId.get(question.id) ?? null}
 							{#if section && index === 0}
-								<div class="bg-section-header mb-4 rounded-2xl border p-4 shadow-sm">
+								<div
+									id="question-{absoluteIndex}-banner"
+									class="bg-section-header mb-4 rounded-2xl border p-4 shadow-sm"
+								>
 									<p class="text-card-foreground text-sm font-semibold">{section.title}</p>
 									{#if section.description}
 										<RichText
@@ -269,7 +276,10 @@
 									? (sectionByQuestionId.get(previousQuestion.id) ?? null)
 									: null}
 								{#if previousSection?.id !== section.id}
-									<div class="bg-section-header mb-4 rounded-2xl border p-4 shadow-sm">
+									<div
+										id="question-{absoluteIndex}-banner"
+										class="bg-section-header mb-4 rounded-2xl border p-4 shadow-sm"
+									>
 										<p class="text-card-foreground text-sm font-semibold">{section.title}</p>
 										{#if section.description}
 											<RichText
@@ -402,8 +412,12 @@
 													method="POST"
 													use:enhance={handleSubmitTestEnhance}
 												>
-													<Button type="submit" disabled={isSubmittingTest} class="w-full"
-														onclick={() => questionCardRef?.flushTime?.()}>
+													<Button
+														type="submit"
+														disabled={isSubmittingTest}
+														class="w-full"
+														onclick={() => questionCardRef?.flushTime?.()}
+													>
 														{#if isSubmittingTest}
 															<Spinner />
 														{/if}

--- a/src/lib/components/Question.svelte.test.ts
+++ b/src/lib/components/Question.svelte.test.ts
@@ -3,8 +3,13 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import Question from './Question.svelte';
 import {
 	mockCandidate,
+	mockMultipleChoiceQuestion,
+	mockOptionalQuestion,
 	mockQuestions,
+	mockQuestionSets,
 	mockSectionedTestQuestionsResponse,
+	mockSingleChoiceQuestion,
+	mockSubjectiveQuestion,
 	mockTestData,
 	setLocaleForTests
 } from '$lib/test-utils';
@@ -246,9 +251,11 @@ describe('Question', () => {
 		render(Question, {
 			props: {
 				candidate: mockCandidate,
+				// all 3 questions on one page, so Chemistry's banner renders mid-page
+				// (not as the page's first question) with its default attempt-all limit
 				testQuestions: {
 					...mockSectionedTestQuestionsResponse,
-					question_pagination: 2
+					question_pagination: 3
 				},
 				testDetails
 			}
@@ -257,6 +264,8 @@ describe('Question', () => {
 		await vi.waitFor(() => {
 			expect(screen.getAllByText('Physics').length).toBeGreaterThan(0);
 			expect(screen.getAllByText('Section A').length).toBeGreaterThan(0);
+			expect(screen.getAllByText('Chemistry').length).toBeGreaterThan(0);
+			expect(screen.getAllByText(/You may attempt all questions/i).length).toBeGreaterThan(0);
 		});
 	});
 
@@ -297,6 +306,56 @@ describe('Question', () => {
 		const banner = document.getElementById('question-0-banner');
 		expect(banner).toBeInTheDocument();
 		expect(banner).toHaveClass('bg-section-header');
+	});
+
+	it('should render a new section banner mid-page, with its own attempt limit, when a section changes without starting the page', async () => {
+		const restrictedSections = [
+			{
+				...mockQuestionSets[0],
+				max_questions_allowed_to_attempt: 1, // fewer than its 2 questions
+				question_revisions: [mockSingleChoiceQuestion, mockMultipleChoiceQuestion]
+			},
+			{
+				...mockQuestionSets[1],
+				id: 13,
+				title: 'Biology',
+				description: 'Section C',
+				max_questions_allowed_to_attempt: 1, // fewer than its 2 questions
+				question_revisions: [mockOptionalQuestion, mockSubjectiveQuestion]
+			}
+		];
+
+		render(Question, {
+			props: {
+				candidate: mockCandidate,
+				testQuestions: {
+					question_revisions: [
+						mockSingleChoiceQuestion,
+						mockMultipleChoiceQuestion,
+						mockOptionalQuestion,
+						mockSubjectiveQuestion
+					],
+					question_sets: restrictedSections,
+					question_pagination: 4 // all four questions share one page
+				},
+				testDetails
+			}
+		});
+
+		await vi.waitFor(() => {
+			expect(screen.getAllByText('Biology').length).toBeGreaterThan(0);
+		});
+
+		// Biology starts at absolute index 2, mid-page rather than at the page's
+		// first question — exercises the previousSection?.id !== section.id branch
+		expect(document.getElementById('question-2-banner')).toBeInTheDocument();
+
+		// both sections restrict attempts below their question count, so the
+		// "attempt up to N" text renders instead of "attempt all"
+		expect(screen.queryAllByText(/You may attempt all questions/i)).toHaveLength(0);
+		expect(
+			screen.getAllByText((text) => text.includes('You may attempt up to 1 questions')).length
+		).toBeGreaterThanOrEqual(2);
 	});
 
 	describe('bottom navigation bar', () => {

--- a/src/lib/components/Question.svelte.test.ts
+++ b/src/lib/components/Question.svelte.test.ts
@@ -260,6 +260,45 @@ describe('Question', () => {
 		});
 	});
 
+	it('should not render a section banner when the test has no question sets', async () => {
+		render(Question, {
+			props: {
+				candidate: mockCandidate,
+				testQuestions,
+				testDetails
+			}
+		});
+
+		await vi.waitFor(() => {
+			expect(screen.getByText(mockQuestions[0].question_text)).toBeInTheDocument();
+		});
+
+		expect(document.querySelector('.bg-section-header')).not.toBeInTheDocument();
+	});
+
+	it('should tag the section banner with an id matching its first question for scroll targeting', async () => {
+		render(Question, {
+			props: {
+				candidate: mockCandidate,
+				testQuestions: {
+					...mockSectionedTestQuestionsResponse,
+					question_pagination: 2
+				},
+				testDetails
+			}
+		});
+
+		await vi.waitFor(() => {
+			expect(screen.getAllByText('Section A').length).toBeGreaterThan(0);
+		});
+
+		// scrollToQuestion() prefers `question-{index}-banner` over `question-{index}`
+		// so the whole section banner (not just the question card) scrolls into view
+		const banner = document.getElementById('question-0-banner');
+		expect(banner).toBeInTheDocument();
+		expect(banner).toHaveClass('bg-section-header');
+	});
+
 	describe('bottom navigation bar', () => {
 		it('should show page info text', async () => {
 			render(Question, {


### PR DESCRIPTION
Fixes #272 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation to scroll to the relevant section banner when available, with fallback to the question card.
  * Added stable IDs to section headers for more reliable navigation.
  * Correctly displays section-specific attempt limits.

* **Tests**
  * Added coverage for section banners, banner IDs, unsectioned tests, and multiple section attempt limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->