### PR TITLE
Show Public Tags on Candidate Review Page

### DIFF
--- a/src/lib/components/QuestionCard.svelte
+++ b/src/lib/components/QuestionCard.svelte
@@ -117,7 +117,12 @@
 			if (result?.correct_answer != null) {
 				selectedQuestions = selectedQuestions.map((q) =>
 					q.question_revision_id === question.id
-						? { ...q, correct_answer: result.correct_answer, solution: result.solution }
+						? {
+								...q,
+								correct_answer: result.correct_answer,
+								solution: result.solution,
+								tags: result.tags
+							}
 						: q
 				);
 				updateStore();
@@ -575,6 +580,23 @@
 			>
 				{$t('View Feedback')}
 			</Button>
+		{/if}
+
+		{#if showFeedback && isLocked && currentSelection?.tags?.length}
+			<div class="mt-4 flex flex-col gap-2">
+				{#each currentSelection.tags as tagGroup (tagGroup.tag_type)}
+					<div class="flex flex-wrap items-center gap-2">
+						<span class="text-foreground text-sm font-semibold">{tagGroup.tag_type}:</span>
+						{#each tagGroup.tag as tagValue (tagValue)}
+							<span
+								class="bg-secondary text-secondary-foreground rounded-full px-3 py-1 text-xs font-medium"
+							>
+								{tagValue}
+							</span>
+						{/each}
+					</div>
+				{/each}
+			</div>
 		{/if}
 
 		{#if showFeedback && isLocked && currentSelection?.solution}

--- a/src/lib/components/QuestionCard.svelte.test.ts
+++ b/src/lib/components/QuestionCard.svelte.test.ts
@@ -4088,6 +4088,187 @@ describe('QuestionCard', () => {
 		});
 	});
 
+	describe('Tags panel', () => {
+		const singleOptions = mockSingleChoiceQuestion.options as TOptions[];
+
+		const lockedWithTags = [
+			{
+				question_revision_id: mockSingleChoiceQuestion.id,
+				response: [singleOptions[1].id],
+				visited: true,
+				time_spent: 10,
+				bookmarked: false,
+				is_reviewed: true,
+				correct_answer: [singleOptions[1].id],
+				tags: [{ tag_type: 'Difficulty', tag: ['Medium'] }]
+			}
+		];
+
+		const lockedWithoutTags = [
+			{
+				question_revision_id: mockSingleChoiceQuestion.id,
+				response: [singleOptions[1].id],
+				visited: true,
+				time_spent: 10,
+				bookmarked: false,
+				is_reviewed: true,
+				correct_answer: [singleOptions[1].id]
+			}
+		];
+
+		it('shows the tag_type label and value when feedback is locked and tags are present', () => {
+			render(QuestionCard, {
+				props: {
+					question: mockSingleChoiceQuestion,
+					serialNumber: 1,
+					candidate: mockCandidate,
+					totalQuestions: 10,
+					selectedQuestions: lockedWithTags,
+					showFeedback: true
+				}
+			});
+
+			expect(screen.getByText('Difficulty:')).toBeInTheDocument();
+			expect(screen.getByText('Medium')).toBeInTheDocument();
+		});
+
+		it('does not show the tags panel when the question has no tags', () => {
+			render(QuestionCard, {
+				props: {
+					question: mockSingleChoiceQuestion,
+					serialNumber: 1,
+					candidate: mockCandidate,
+					totalQuestions: 10,
+					selectedQuestions: lockedWithoutTags,
+					showFeedback: true
+				}
+			});
+
+			expect(screen.queryByText('Difficulty:')).not.toBeInTheDocument();
+		});
+
+		it('does not show the tags panel when showFeedback is false, even with tags present', () => {
+			render(QuestionCard, {
+				props: {
+					question: mockSingleChoiceQuestion,
+					serialNumber: 1,
+					candidate: mockCandidate,
+					totalQuestions: 10,
+					selectedQuestions: lockedWithTags,
+					showFeedback: false
+				}
+			});
+
+			expect(screen.queryByText('Difficulty:')).not.toBeInTheDocument();
+			expect(screen.queryByText('Medium')).not.toBeInTheDocument();
+		});
+
+		it('does not show the tags panel before feedback has been viewed, even with tags present', () => {
+			const answeredNotViewedWithTags = [
+				{
+					question_revision_id: mockSingleChoiceQuestion.id,
+					response: [singleOptions[1].id],
+					visited: true,
+					time_spent: 10,
+					bookmarked: false,
+					is_reviewed: false,
+					tags: [{ tag_type: 'Difficulty', tag: ['Medium'] }]
+				}
+			];
+
+			render(QuestionCard, {
+				props: {
+					question: mockSingleChoiceQuestion,
+					serialNumber: 1,
+					candidate: mockCandidate,
+					totalQuestions: 10,
+					selectedQuestions: answeredNotViewedWithTags,
+					showFeedback: true
+				}
+			});
+
+			expect(screen.queryByText('Difficulty:')).not.toBeInTheDocument();
+		});
+
+		it('renders the tags returned by the API after clicking "View Result"', async () => {
+			vi.mocked(fetch).mockResolvedValueOnce(
+				createMockResponse({
+					success: true,
+					correct_answer: [singleOptions[1].id],
+					tags: [{ tag_type: 'Difficulty', tag: ['Medium'] }]
+				}) as unknown as Response
+			);
+
+			const answeredNotViewed = [
+				{
+					question_revision_id: mockSingleChoiceQuestion.id,
+					response: [singleOptions[1].id],
+					visited: true,
+					time_spent: 10,
+					bookmarked: false,
+					is_reviewed: false
+				}
+			];
+
+			render(QuestionCard, {
+				props: {
+					question: mockSingleChoiceQuestion,
+					serialNumber: 1,
+					candidate: mockCandidate,
+					totalQuestions: 10,
+					selectedQuestions: answeredNotViewed,
+					showFeedback: true
+				}
+			});
+
+			await screen.getByRole('button', { name: /view result/i }).click();
+
+			await waitFor(() => {
+				expect(screen.getByText('Difficulty:')).toBeInTheDocument();
+				expect(screen.getByText('Medium')).toBeInTheDocument();
+			});
+		});
+
+		it('does not render a tags panel when the API response has no tags', async () => {
+			vi.mocked(fetch).mockResolvedValueOnce(
+				createMockResponse({
+					success: true,
+					correct_answer: [singleOptions[1].id],
+					tags: null
+				}) as unknown as Response
+			);
+
+			const answeredNotViewed = [
+				{
+					question_revision_id: mockSingleChoiceQuestion.id,
+					response: [singleOptions[1].id],
+					visited: true,
+					time_spent: 10,
+					bookmarked: false,
+					is_reviewed: false
+				}
+			];
+
+			render(QuestionCard, {
+				props: {
+					question: mockSingleChoiceQuestion,
+					serialNumber: 1,
+					candidate: mockCandidate,
+					totalQuestions: 10,
+					selectedQuestions: answeredNotViewed,
+					showFeedback: true
+				}
+			});
+
+			await screen.getByRole('button', { name: /view result/i }).click();
+
+			await waitFor(() => {
+				expect(screen.getByText(/^Correct:/)).toBeInTheDocument();
+			});
+			expect(screen.queryByText('Difficulty:')).not.toBeInTheDocument();
+		});
+	});
+
 	describe('Marking scheme modal (mobile) vs dropdown (desktop)', () => {
 		const defaultProps = {
 			serialNumber: 1,

--- a/src/lib/components/ViewFeedback.svelte
+++ b/src/lib/components/ViewFeedback.svelte
@@ -150,6 +150,23 @@
 					/>
 				{/if}
 
+				{#if item.fb.tags?.length}
+					<div class="mt-4 flex flex-col gap-2">
+						{#each item.fb.tags as tagGroup (tagGroup.tag_type)}
+							<div class="flex flex-wrap items-center gap-2">
+								<span class="text-foreground text-sm font-semibold">{tagGroup.tag_type}:</span>
+								{#each tagGroup.tag as tagValue (tagValue)}
+									<span
+										class="bg-secondary text-secondary-foreground rounded-full px-3 py-1 text-xs font-medium"
+									>
+										{tagValue}
+									</span>
+								{/each}
+							</div>
+						{/each}
+					</div>
+				{/if}
+
 				{#if item.fb.solution}
 					<div class="bg-muted mt-4 rounded-lg p-4">
 						<p class="text-foreground mb-1 text-sm font-semibold">{$t('Solution')}</p>

--- a/src/lib/components/ViewFeedback.svelte.test.ts
+++ b/src/lib/components/ViewFeedback.svelte.test.ts
@@ -211,6 +211,90 @@ describe('ViewFeedback', () => {
 		});
 	});
 
+	describe('tags panel', () => {
+		it('should display a tag_type label and its value', () => {
+			const feedback = [
+				{ ...createFeedback(1, [102], [102]), tags: [{ tag_type: 'Difficulty', tag: ['Easy'] }] }
+			];
+
+			render(ViewFeedback, {
+				props: { candidate: mockCandidate, feedback, testQuestions: mockTestQuestionsResponse }
+			});
+
+			expect(screen.getByText('Difficulty:')).toBeInTheDocument();
+			expect(screen.getByText('Easy')).toBeInTheDocument();
+		});
+
+		it('should display multiple values for a single tag_type', () => {
+			const feedback = [
+				{
+					...createFeedback(1, [102], [102]),
+					tags: [{ tag_type: 'Subject', tag: ['Math', 'Algebra'] }]
+				}
+			];
+
+			render(ViewFeedback, {
+				props: { candidate: mockCandidate, feedback, testQuestions: mockTestQuestionsResponse }
+			});
+
+			expect(screen.getByText('Subject:')).toBeInTheDocument();
+			expect(screen.getByText('Math')).toBeInTheDocument();
+			expect(screen.getByText('Algebra')).toBeInTheDocument();
+		});
+
+		it('should display multiple tag_type groups', () => {
+			const feedback = [
+				{
+					...createFeedback(1, [102], [102]),
+					tags: [
+						{ tag_type: 'Difficulty', tag: ['Easy'] },
+						{ tag_type: 'Subject', tag: ['Math'] }
+					]
+				}
+			];
+
+			render(ViewFeedback, {
+				props: { candidate: mockCandidate, feedback, testQuestions: mockTestQuestionsResponse }
+			});
+
+			expect(screen.getByText('Difficulty:')).toBeInTheDocument();
+			expect(screen.getByText('Subject:')).toBeInTheDocument();
+		});
+
+		it('should not display a tags panel when the feedback entry has no tags', () => {
+			const feedback = [createFeedback(1, [102], [102])];
+
+			render(ViewFeedback, {
+				props: { candidate: mockCandidate, feedback, testQuestions: mockTestQuestionsResponse }
+			});
+
+			expect(screen.queryByText('Difficulty:')).not.toBeInTheDocument();
+		});
+
+		it('should not display a tags panel when tags is an empty array', () => {
+			const feedback = [{ ...createFeedback(1, [102], [102]), tags: [] }];
+
+			render(ViewFeedback, {
+				props: { candidate: mockCandidate, feedback, testQuestions: mockTestQuestionsResponse }
+			});
+
+			expect(screen.queryByText(/:$/)).not.toBeInTheDocument();
+		});
+
+		it('should only display a tags panel for the question that has tags', () => {
+			const feedback = [
+				{ ...createFeedback(1, [102], [102]), tags: [{ tag_type: 'Difficulty', tag: ['Easy'] }] },
+				createFeedback(2, [201], [201, 202])
+			];
+
+			render(ViewFeedback, {
+				props: { candidate: mockCandidate, feedback, testQuestions: mockTestQuestionsResponse }
+			});
+
+			expect(screen.getAllByText('Difficulty:')).toHaveLength(1);
+		});
+	});
+
 	describe('single-choice questions', () => {
 		it('should render all options for a single-choice question', () => {
 			const feedback = [createFeedback(1, [102], [102])];

--- a/src/lib/helpers/feedbackHelpers.test.ts
+++ b/src/lib/helpers/feedbackHelpers.test.ts
@@ -264,7 +264,8 @@ describe('normalizeFeedbackEntry', () => {
 			question_revision_id: 1,
 			submitted_answer: [102],
 			correct_answer: [102],
-			solution: null
+			solution: null,
+			tags: []
 		});
 	});
 
@@ -279,8 +280,20 @@ describe('normalizeFeedbackEntry', () => {
 			question_revision_id: 2,
 			submitted_answer: [201, 203],
 			correct_answer: [201, 202],
-			solution: null
+			solution: null,
+			tags: []
 		});
+	});
+
+	it('passes through tags when the row has them', () => {
+		expect(
+			normalizeFeedbackEntry({
+				question_revision_id: 1,
+				submitted_answer: '[102]',
+				correct_answer: [102],
+				tags: [{ tag_type: 'Difficulty', tag: ['Easy'] }]
+			}).tags
+		).toEqual([{ tag_type: 'Difficulty', tag: ['Easy'] }]);
 	});
 
 	it('passes through a solution when the row has one', () => {

--- a/src/lib/helpers/feedbackHelpers.ts
+++ b/src/lib/helpers/feedbackHelpers.ts
@@ -1,4 +1,4 @@
-import { question_type_enum } from '$lib/types';
+import { question_type_enum, type TFeedbackTag } from '$lib/types';
 
 export const GRADABLE_QUESTION_TYPES = new Set([
 	question_type_enum.SINGLE,
@@ -13,6 +13,7 @@ export type TFeedbackEntry = {
 	submitted_answer: number[] | string;
 	correct_answer: number[];
 	solution?: string | null;
+	tags?: TFeedbackTag[];
 };
 
 /**
@@ -26,6 +27,7 @@ export const normalizeFeedbackEntry = (item: {
 	submitted_answer: string | null;
 	correct_answer: number[];
 	solution?: string | null;
+	tags?: TFeedbackTag[];
 }): TFeedbackEntry => {
 	let submitted: number[] | string = [];
 	if (item.submitted_answer) {
@@ -40,7 +42,8 @@ export const normalizeFeedbackEntry = (item: {
 		question_revision_id: item.question_revision_id,
 		submitted_answer: submitted,
 		correct_answer: item.correct_answer,
-		solution: item.solution ?? null
+		solution: item.solution ?? null,
+		tags: item.tags ?? []
 	};
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,11 @@ export type TCandidate = {
 	candidate_test_id: number;
 };
 
+export type TFeedbackTag = {
+	tag_type: string;
+	tag: string[];
+};
+
 export type TSelection = {
 	question_revision_id: number;
 	response: number[] | string;
@@ -12,6 +17,7 @@ export type TSelection = {
 	is_reviewed?: boolean;
 	correct_answer?: number[] | number | null | string;
 	solution?: string | null;
+	tags?: TFeedbackTag[] | null;
 };
 
 export type TTestSession = {
@@ -201,6 +207,7 @@ export type TFeedback = {
 	submitted_answer: number[] | string;
 	correct_answer: number[] | number;
 	solution?: string | null;
+	tags?: TFeedbackTag[];
 };
 
 export type TOmrMode = 'NEVER' | 'ALWAYS' | 'OPTIONAL';

--- a/src/routes/test/[slug]/api/submit-answer/+server.ts
+++ b/src/routes/test/[slug]/api/submit-answer/+server.ts
@@ -91,6 +91,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 
 		let correct_answer = null;
 		let solution = null;
+		let tags = null;
 
 		if (is_reviewed && response && response.length > 0) {
 			try {
@@ -103,12 +104,13 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 					if (feedbackData.length > 0) {
 						correct_answer = feedbackData[0].correct_answer;
 						solution = feedbackData[0].solution ?? null;
+						tags = feedbackData[0].tags ?? null;
 					}
 				}
 			} catch {}
 		}
 
-		return new Response(JSON.stringify({ success: true, correct_answer, solution }), {
+		return new Response(JSON.stringify({ success: true, correct_answer, solution, tags }), {
 			status: 200,
 			headers: { 'Content-Type': 'application/json' }
 		});

--- a/src/routes/test/[slug]/api/submit-answer/server.test.ts
+++ b/src/routes/test/[slug]/api/submit-answer/server.test.ts
@@ -156,6 +156,79 @@ describe('POST /test/[slug]/api/submit-answer', () => {
 		expect(fetch).toHaveBeenCalledTimes(1);
 	});
 
+	it('should return the tags when the review-feedback entry has them', async () => {
+		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
+		vi.mocked(fetch)
+			.mockResolvedValueOnce(createMockResponse({ success: true }) as unknown as Response)
+			.mockResolvedValueOnce(
+				createMockResponse([
+					{
+						question_revision_id: 1,
+						submitted_answer: '[101]',
+						correct_answer: [101],
+						tags: [{ tag_type: 'Difficulty', tag: ['Easy'] }]
+					}
+				]) as unknown as Response
+			);
+
+		const mockCookies = createMockCookies();
+		const request = createMockRequest({
+			question_revision_id: 1,
+			response: [101],
+			candidate: mockCandidate,
+			is_reviewed: true
+		});
+		const response = await POST({ request, cookies: mockCookies } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.tags).toEqual([{ tag_type: 'Difficulty', tag: ['Easy'] }]);
+	});
+
+	it('should return tags as null when the review-feedback entry has none', async () => {
+		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
+		vi.mocked(fetch)
+			.mockResolvedValueOnce(createMockResponse({ success: true }) as unknown as Response)
+			.mockResolvedValueOnce(
+				createMockResponse([
+					{ question_revision_id: 1, submitted_answer: '[101]', correct_answer: [101] }
+				]) as unknown as Response
+			);
+
+		const mockCookies = createMockCookies();
+		const request = createMockRequest({
+			question_revision_id: 1,
+			response: [101],
+			candidate: mockCandidate,
+			is_reviewed: true
+		});
+		const response = await POST({ request, cookies: mockCookies } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.tags).toBeNull();
+	});
+
+	it('should return tags as null when feedback is not fetched (is_reviewed is not true)', async () => {
+		vi.mocked(getCandidate).mockReturnValue(mockCandidate);
+		vi.mocked(fetch).mockResolvedValueOnce(
+			createMockResponse({ success: true }) as unknown as Response
+		);
+
+		const mockCookies = createMockCookies();
+		const request = createMockRequest({
+			question_revision_id: 1,
+			response: [101],
+			candidate: mockCandidate
+		});
+		const response = await POST({ request, cookies: mockCookies } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.tags).toBeNull();
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
 	it('should return 401 when cookie candidate is missing', async () => {
 		vi.mocked(getCandidate).mockReturnValue(null);
 


### PR DESCRIPTION
Fixes #276 

~~The PR can be rebased to Main after merger of Display Solution PR - https://github.com/sashakt-platform/sashakt-webapp/pull/280~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feedback results now include relevant tags alongside correct answers and solutions.
  * Grouped tag labels and values are displayed on locked feedback cards and result views.
  * Tags are omitted when unavailable, feedback is disabled, or results have not been viewed.

* **Tests**
  * Added coverage for tag rendering, persistence, API responses, empty tags, and multiple tag groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->