### PR TITLE
Render the section banner from section data

### DIFF
--- a/src/lib/components/LandingPage.svelte
+++ b/src/lib/components/LandingPage.svelte
@@ -127,7 +127,7 @@
 		{/if}
 	</div>
 	{#if questionSets.length > 0}
-		<div class="align-center mt-8 border-t pt-4">
+		<div class="align-center mx-auto mt-8 max-w-xl border-t pt-4 lg:max-w-4xl">
 			<h2 class="text-foreground mb-4 text-center text-sm font-bold uppercase">
 				{$t('Sections')}
 			</h2>

--- a/src/lib/components/LandingPage.svelte
+++ b/src/lib/components/LandingPage.svelte
@@ -14,6 +14,7 @@
 	import type { TQuestionSetSummary } from '$lib/types';
 	import PreTestTimer from './PreTestTimer.svelte';
 	import RichText from './RichText.svelte';
+	import SectionBanner from './SectionBanner.svelte';
 	import { t } from 'svelte-i18n';
 
 	let {
@@ -130,32 +131,17 @@
 			</h2>
 			<div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
 				{#each questionSets as questionSet (`${questionSet.id ?? questionSet.title}-${questionSet.display_order}`)}
-					<div class="bg-card mx-auto w-full rounded-2xl border p-4 lg:w-2/3">
-						<div class="flex items-start justify-between gap-4">
-							<div>
-								<h3 class="text-sm font-semibold">{questionSet.title}</h3>
-								{#if questionSet.description}
-									<RichText
-										content={questionSet.description}
-										class="text-muted-foreground mt-1 text-sm"
-									/>
-								{/if}
-							</div>
-							<p class="text-muted-foreground shrink-0 text-xs">
-								{getQuestionSetQuestionCount(questionSet)}
-								{$t('questions')}
-							</p>
-						</div>
-						<p class="text-muted-foreground mt-3 text-sm">
-							{#if canAttemptAllQuestions(questionSet.max_questions_allowed_to_attempt, getQuestionSetQuestionCount(questionSet))}
-								{$t('You may attempt all questions in this section.')}
-							{:else}
-								{$t('You may attempt up to {count} questions in this section.', {
-									values: { count: questionSet.max_questions_allowed_to_attempt }
-								})}
-							{/if}
-						</p>
-					</div>
+					<SectionBanner
+						title={questionSet.title}
+						description={questionSet.description}
+						maxQuestionsAllowedToAttempt={questionSet.max_questions_allowed_to_attempt}
+						questionCount={getQuestionSetQuestionCount(questionSet)}
+						questions={questionSet.question_revisions ?? []}
+						markingScheme={questionSet.marking_scheme}
+						showMarkingScheme={testDetails?.show_marks ?? true}
+						showQuestionCount
+						class="bg-card mx-auto w-full rounded-2xl border p-4 lg:w-2/3"
+					/>
 				{/each}
 			</div>
 		</div>

--- a/src/lib/components/LandingPage.svelte
+++ b/src/lib/components/LandingPage.svelte
@@ -76,7 +76,9 @@
 	);
 </script>
 
-<section class="bg-muted min-h-screen px-4 py-6">
+<!-- pb-32 clears the fixed start bar below; without it the last section card
+     sits underneath it and cannot be scrolled into view. -->
+<section class="bg-muted min-h-screen px-4 pt-6 pb-32">
 	<div class="mx-auto max-w-xl">
 		<div class="mb-6 text-center">
 			<h1 class="text-foreground mb-2 text-2xl leading-tight font-semibold">{testDetails.name}</h1>
@@ -140,7 +142,7 @@
 						markingScheme={questionSet.marking_scheme}
 						showMarkingScheme={testDetails?.show_marks ?? true}
 						showQuestionCount
-						class="bg-card mx-auto w-full rounded-2xl border p-4 lg:w-2/3"
+						class="bg-card h-full w-full rounded-2xl border p-4"
 					/>
 				{/each}
 			</div>

--- a/src/lib/components/LandingPage.svelte.test.ts
+++ b/src/lib/components/LandingPage.svelte.test.ts
@@ -136,7 +136,34 @@ describe('LandingPage', () => {
 		expect(screen.getByText('Sections')).toBeInTheDocument();
 		expect(screen.getByText('Physics')).toBeInTheDocument();
 		expect(screen.getByText('Chemistry')).toBeInTheDocument();
-		expect(screen.getAllByText('You may attempt all questions in this section.')).toHaveLength(2);
+		// The attempt rule is only stated when it restricts the candidate; these
+		// sections let them attempt everything, so the line is deliberately absent.
+		expect(
+			screen.queryByText('You may attempt all questions in this section.')
+		).not.toBeInTheDocument();
+	});
+
+	it('states the attempt rule only when a section caps attempts', () => {
+		render(LandingPage, {
+			props: {
+				testDetails: {
+					...defaultTestDetails,
+					question_sets: [
+						{
+							id: 1,
+							title: 'Physics',
+							display_order: 1,
+							question_count: 10,
+							max_questions_allowed_to_attempt: 5
+						}
+					]
+				}
+			}
+		});
+
+		expect(
+			screen.getByText('You may attempt up to 5 questions in this section.')
+		).toBeInTheDocument();
 	});
 
 	it('should render question set descriptions as html', () => {
@@ -156,8 +183,12 @@ describe('LandingPage', () => {
 
 		expect(screen.getByText('Single correct option')).toBeInTheDocument();
 		expect(screen.getByText('Correct:')).toBeInTheDocument();
-		expect(screen.getByText('+4')).toBeInTheDocument();
 		expect(screen.queryByText(/<u>Single correct option<\/u>/)).not.toBeInTheDocument();
+		// This description is the marking-scheme HTML an external ingest used to
+		// inject. Sashakt now renders the scheme itself, so such a description
+		// duplicates it — hence "+4" legitimately appears twice here. The fix is
+		// upstream (stop sending it), not in this assertion.
+		expect(screen.getAllByText('+4').length).toBeGreaterThan(0);
 	});
 
 	it('should not render instructions section when no instructions', () => {

--- a/src/lib/components/MarkingSchemeInline.svelte
+++ b/src/lib/components/MarkingSchemeInline.svelte
@@ -3,12 +3,10 @@
 	import { t } from 'svelte-i18n';
 
 	/**
-	 * A one-line summary of a marking scheme, for section headers.
-	 *
-	 * MarkingSchemeContent is a stacked key/value list sized for the per-question
-	 * popover, where it is the only thing on screen. In a header that stretches
-	 * the full content width it reads badly — `justify-between` pushes each value
-	 * far from its label, and the partial ladder turns two lines into eight.
+	 * A one-line marking scheme, for section headers. MarkingSchemeContent is a
+	 * stacked list sized for the per-question popover; stretched across a header
+	 * its values sit far from their labels and the partial ladder runs to eight
+	 * lines.
 	 */
 	let {
 		scheme,
@@ -18,8 +16,8 @@
 		questionType?: question_type_enum;
 	} = $props();
 
-	// The ladder applies to multi-choice; an undefined type means the caller
-	// could not tell, so show it rather than hide a scheme that exists.
+	// An undefined type means the caller could not tell, so show the ladder
+	// rather than hide a scheme that exists.
 	const showPartial = $derived(
 		!!scheme.partial?.correct_answers?.length &&
 			(questionType === undefined || questionType === question_type_enum.MULTIPLE)
@@ -27,9 +25,7 @@
 
 	const wrong = $derived(scheme.wrong > 0 ? `+${scheme.wrong}` : `${scheme.wrong}`);
 
-	// "+1 / +2 / +3" — the ladder in reading order, without naming each count.
-	// The per-question popover spells out "N correct selected" for anyone who
-	// wants the detail; this is the at-a-glance version.
+	// "+1 / +2 / +3" — the popover spells out which count earns which.
 	const partialSummary = $derived(
 		(scheme.partial?.correct_answers ?? []).map((rule) => `+${rule.marks}`).join(' / ')
 	);

--- a/src/lib/components/MarkingSchemeInline.svelte
+++ b/src/lib/components/MarkingSchemeInline.svelte
@@ -35,16 +35,16 @@
 
 <p class="text-muted-foreground mt-2 text-xs">
 	<span class="text-success font-medium">+{scheme.correct}</span>
-	{$t('correct')}
+	{$t('Correct')}
 	<span class="mx-1 opacity-40">·</span>
 	<span class="text-error font-medium">{wrong}</span>
-	{$t('wrong')}
+	{$t('Incorrect')}
 	<span class="mx-1 opacity-40">·</span>
 	<span class="font-medium">{scheme.skipped}</span>
-	{$t('skipped')}
+	{$t('Unanswered')}
 	{#if showPartial && partialSummary}
 		<span class="mx-1 opacity-40">·</span>
-		{$t('partial')}
+		{$t('Partial')}
 		<span class="text-success font-medium">{partialSummary}</span>
 		{$t('if no wrong option is selected')}
 	{/if}

--- a/src/lib/components/MarkingSchemeInline.svelte
+++ b/src/lib/components/MarkingSchemeInline.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { TMarks, question_type_enum } from '$lib/types';
+	import { question_type_enum, type TMarks } from '$lib/types';
 	import { t } from 'svelte-i18n';
 
 	/**
@@ -18,9 +18,11 @@
 		questionType?: question_type_enum;
 	} = $props();
 
+	// The ladder applies to multi-choice; an undefined type means the caller
+	// could not tell, so show it rather than hide a scheme that exists.
 	const showPartial = $derived(
 		!!scheme.partial?.correct_answers?.length &&
-			(questionType === undefined || questionType === 'multi-choice')
+			(questionType === undefined || questionType === question_type_enum.MULTIPLE)
 	);
 
 	const wrong = $derived(scheme.wrong > 0 ? `+${scheme.wrong}` : `${scheme.wrong}`);

--- a/src/lib/components/MarkingSchemeInline.svelte
+++ b/src/lib/components/MarkingSchemeInline.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import type { TMarks, question_type_enum } from '$lib/types';
+	import { t } from 'svelte-i18n';
+
+	/**
+	 * A one-line summary of a marking scheme, for section headers.
+	 *
+	 * MarkingSchemeContent is a stacked key/value list sized for the per-question
+	 * popover, where it is the only thing on screen. In a header that stretches
+	 * the full content width it reads badly — `justify-between` pushes each value
+	 * far from its label, and the partial ladder turns two lines into eight.
+	 */
+	let {
+		scheme,
+		questionType = undefined
+	}: {
+		scheme: TMarks;
+		questionType?: question_type_enum;
+	} = $props();
+
+	const showPartial = $derived(
+		!!scheme.partial?.correct_answers?.length &&
+			(questionType === undefined || questionType === 'multi-choice')
+	);
+
+	const wrong = $derived(scheme.wrong > 0 ? `+${scheme.wrong}` : `${scheme.wrong}`);
+
+	// "+1 / +2 / +3" — the ladder in reading order, without naming each count.
+	// The per-question popover spells out "N correct selected" for anyone who
+	// wants the detail; this is the at-a-glance version.
+	const partialSummary = $derived(
+		(scheme.partial?.correct_answers ?? []).map((rule) => `+${rule.marks}`).join(' / ')
+	);
+</script>
+
+<p class="text-muted-foreground mt-2 text-xs">
+	<span class="text-success font-medium">+{scheme.correct}</span>
+	{$t('correct')}
+	<span class="mx-1 opacity-40">·</span>
+	<span class="text-error font-medium">{wrong}</span>
+	{$t('wrong')}
+	<span class="mx-1 opacity-40">·</span>
+	<span class="font-medium">{scheme.skipped}</span>
+	{$t('skipped')}
+	{#if showPartial && partialSummary}
+		<span class="mx-1 opacity-40">·</span>
+		{$t('partial')}
+		<span class="text-success font-medium">{partialSummary}</span>
+		{$t('if no wrong option is selected')}
+	{/if}
+</p>

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -258,7 +258,7 @@
 									questions={section.question_revisions}
 									markingScheme={section.marking_scheme}
 									showMarkingScheme={testDetails?.show_marks ?? true}
-									class="bg-section-header mb-4 rounded-2xl border p-4 shadow-sm"
+									class="bg-section-header mb-3 rounded-xl border px-4 py-3 shadow-sm"
 								/>
 							{:else if section}
 								{@const previousQuestion = questions[absoluteIndex - 1]}
@@ -275,7 +275,7 @@
 										questions={section.question_revisions}
 										markingScheme={section.marking_scheme}
 										showMarkingScheme={testDetails?.show_marks ?? true}
-										class="bg-section-header mb-4 rounded-2xl border p-4 shadow-sm"
+										class="bg-section-header mb-3 rounded-xl border px-4 py-3 shadow-sm"
 									/>
 								{/if}
 							{/if}

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -4,13 +4,13 @@
 	import QuestionCard from '$lib/components/QuestionCard.svelte';
 	import QuestionPaletteModal from '$lib/components/QuestionPaletteModal.svelte';
 	import QuestionPaletteSidebar from '$lib/components/QuestionPaletteSidebar.svelte';
-	import RichText from '$lib/components/RichText.svelte';
+	import SectionBanner from '$lib/components/SectionBanner.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Pagination from '$lib/components/ui/pagination/index.js';
 	import { Spinner } from '$lib/components/ui/spinner';
 	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import { canAttemptAllQuestions, normalizeTestQuestions } from '$lib/helpers/questionSetHelpers';
+	import { normalizeTestQuestions } from '$lib/helpers/questionSetHelpers';
 	import { countQuestionStatuses } from '$lib/helpers/questionPaletteHelpers';
 	import { answeredAllMandatory, answeredCurrentMandatory } from '$lib/helpers/testFunctionalities';
 	import {
@@ -249,54 +249,34 @@
 							{@const absoluteIndex = (currentPage - 1) * perPage + index}
 							{@const section = sectionByQuestionId.get(question.id) ?? null}
 							{#if section && index === 0}
-								<div
+								<SectionBanner
 									id="question-{absoluteIndex}-banner"
+									title={section.title}
+									description={section.description}
+									maxQuestionsAllowedToAttempt={section.max_questions_allowed_to_attempt}
+									questionCount={section.question_revisions.length}
+									questions={section.question_revisions}
+									markingScheme={section.marking_scheme}
+									showMarkingScheme={testDetails?.show_marks ?? true}
 									class="bg-section-header mb-4 rounded-2xl border p-4 shadow-sm"
-								>
-									<p class="text-card-foreground text-sm font-semibold">{section.title}</p>
-									{#if section.description}
-										<RichText
-											content={section.description}
-											class="text-muted-foreground mt-1 text-sm"
-										/>
-									{/if}
-									<p class="text-muted-foreground mt-2 text-sm">
-										{#if canAttemptAllQuestions(section.max_questions_allowed_to_attempt, section.question_revisions.length)}
-											{$t('You may attempt all questions in this section.')}
-										{:else}
-											{$t('You may attempt up to {count} questions in this section.', {
-												values: { count: section.max_questions_allowed_to_attempt }
-											})}
-										{/if}
-									</p>
-								</div>
+								/>
 							{:else if section}
 								{@const previousQuestion = questions[absoluteIndex - 1]}
 								{@const previousSection = previousQuestion
 									? (sectionByQuestionId.get(previousQuestion.id) ?? null)
 									: null}
 								{#if previousSection?.id !== section.id}
-									<div
+									<SectionBanner
 										id="question-{absoluteIndex}-banner"
+										title={section.title}
+										description={section.description}
+										maxQuestionsAllowedToAttempt={section.max_questions_allowed_to_attempt}
+										questionCount={section.question_revisions.length}
+										questions={section.question_revisions}
+										markingScheme={section.marking_scheme}
+										showMarkingScheme={testDetails?.show_marks ?? true}
 										class="bg-section-header mb-4 rounded-2xl border p-4 shadow-sm"
-									>
-										<p class="text-card-foreground text-sm font-semibold">{section.title}</p>
-										{#if section.description}
-											<RichText
-												content={section.description}
-												class="text-muted-foreground mt-1 text-sm"
-											/>
-										{/if}
-										<p class="text-muted-foreground mt-2 text-sm">
-											{#if canAttemptAllQuestions(section.max_questions_allowed_to_attempt, section.question_revisions.length)}
-												{$t('You may attempt all questions in this section.')}
-											{:else}
-												{$t('You may attempt up to {count} questions in this section.', {
-													values: { count: section.max_questions_allowed_to_attempt }
-												})}
-											{/if}
-										</p>
-									</div>
+									/>
 								{/if}
 							{/if}
 							<div id="question-{(currentPage - 1) * perPage + index}">

--- a/src/lib/components/Question.svelte.test.ts
+++ b/src/lib/components/Question.svelte.test.ts
@@ -265,7 +265,9 @@ describe('Question', () => {
 			expect(screen.getAllByText('Physics').length).toBeGreaterThan(0);
 			expect(screen.getAllByText('Section A').length).toBeGreaterThan(0);
 			expect(screen.getAllByText('Chemistry').length).toBeGreaterThan(0);
-			expect(screen.getAllByText(/You may attempt all questions/i).length).toBeGreaterThan(0);
+			// The attempt rule is stated only when it restricts the candidate, so an
+			// uncapped section deliberately shows no such line.
+			expect(screen.queryAllByText(/You may attempt/i)).toHaveLength(0);
 		});
 	});
 

--- a/src/lib/components/QuestionCard.svelte
+++ b/src/lib/components/QuestionCard.svelte
@@ -14,7 +14,11 @@
 	} from '$lib/helpers/answerErrorHelpers';
 	import { question_type_enum, type TCandidate, type TQuestion, type TSelection } from '$lib/types';
 	import { t } from 'svelte-i18n';
-	import { getQuestionResult, GRADABLE_QUESTION_TYPES } from '$lib/helpers/feedbackHelpers';
+	import {
+		getCorrectSelectedCount,
+		getQuestionResult,
+		GRADABLE_QUESTION_TYPES
+	} from '$lib/helpers/feedbackHelpers';
 	import RichText from './RichText.svelte';
 
 	import QuestionMedia from './QuestionMedia.svelte';
@@ -78,6 +82,17 @@
 	const feedbackResult = $derived(
 		isLocked && currentSelection?.correct_answer != null
 			? getQuestionResult(
+					question.question_type,
+					currentSelection?.response,
+					currentSelection?.correct_answer,
+					question.marking_scheme
+				)
+			: null
+	);
+
+	const feedbackCorrectSelected = $derived(
+		feedbackResult === 'partially-correct'
+			? getCorrectSelectedCount(
 					question.question_type,
 					currentSelection?.response,
 					currentSelection?.correct_answer
@@ -478,7 +493,11 @@
 				{/if}
 
 				{#if showFeedback && isLocked && question?.marking_scheme && GRADABLE_QUESTION_TYPES.has(question.question_type)}
-					<ResultBadge result={feedbackResult} scheme={question.marking_scheme} />
+					<ResultBadge
+						result={feedbackResult}
+						scheme={question.marking_scheme}
+						correctSelected={feedbackCorrectSelected}
+					/>
 				{/if}
 
 				{#if showMarkForReviewButton}

--- a/src/lib/components/QuestionPaletteContent.svelte
+++ b/src/lib/components/QuestionPaletteContent.svelte
@@ -75,15 +75,13 @@
 							class="text-muted-foreground mt-1 text-xs leading-relaxed"
 						/>
 					{/if}
-					<p class="text-muted-foreground mt-2 text-xs leading-relaxed">
-						{#if canAttemptAllQuestions(group.section.max_questions_allowed_to_attempt, group.questions.length)}
-							{$t('You may attempt all questions in this section.')}
-						{:else}
+					{#if !canAttemptAllQuestions(group.section.max_questions_allowed_to_attempt, group.questions.length)}
+						<p class="text-muted-foreground mt-2 text-xs leading-relaxed">
 							{$t('You may attempt up to {count} questions in this section.', {
 								values: { count: group.section.max_questions_allowed_to_attempt }
 							})}
-						{/if}
-					</p>
+						</p>
+					{/if}
 					<div class="mt-3 grid gap-2" style:grid-template-columns="repeat({cols}, minmax(0, 1fr))">
 						{#each group.questions as question (question.id)}
 							{@const index = questionIndexById.get(question.id) ?? 0}

--- a/src/lib/components/QuestionPaletteContent.svelte.test.ts
+++ b/src/lib/components/QuestionPaletteContent.svelte.test.ts
@@ -279,6 +279,7 @@ describe('QuestionPaletteContent', () => {
 
 		expect(screen.getByText('Physics')).toBeInTheDocument();
 		expect(screen.getByText('Chemistry')).toBeInTheDocument();
-		expect(screen.getAllByText('You may attempt all questions in this section.')).toHaveLength(2);
+		// Uncapped sections state no attempt rule; only a real cap is worth a line.
+		expect(screen.queryAllByText(/You may attempt/i)).toHaveLength(0);
 	});
 });

--- a/src/lib/components/ResultBadge.svelte
+++ b/src/lib/components/ResultBadge.svelte
@@ -1,34 +1,63 @@
 <script lang="ts">
 	import { t } from 'svelte-i18n';
 	import { cn } from '$lib/utils';
+	import { getPartialMarks, type TQuestionResult } from '$lib/helpers/feedbackHelpers';
 	import type { TMarks } from '$lib/types';
 
 	let {
 		result,
-		scheme
+		scheme,
+		correctSelected = null
 	}: {
-		result: 'correct' | 'incorrect' | 'unattempted' | null | undefined;
+		result: TQuestionResult | null | undefined;
 		scheme: TMarks;
+		/**
+		 * How many correct answers were selected. Required to report the marks a
+		 * partially correct answer earned, since the scheme awards a different
+		 * amount per count.
+		 */
+		correctSelected?: number | null;
 	} = $props();
+
+	const partialMarks = $derived(
+		result === 'partially-correct' && correctSelected != null
+			? getPartialMarks(scheme, correctSelected)
+			: null
+	);
 
 	const variantClass = $derived(
 		result === 'correct'
 			? 'bg-success-subtle text-success'
-			: result === 'incorrect'
-				? 'bg-error-subtle text-error'
-				: result === 'unattempted'
-					? 'bg-muted text-muted-foreground'
-					: null
+			: result === 'partially-correct'
+				? // Partial credit is still credit, so it reads as success -- the ring
+					// and the label distinguish it from a fully correct answer. (Adding a
+					// fourth semantic colour would be a design decision; the palette
+					// currently defines only success, error and warning.)
+					'bg-success-subtle text-success ring-success/40 ring-1 ring-inset'
+				: result === 'incorrect'
+					? 'bg-error-subtle text-error'
+					: result === 'unattempted'
+						? 'bg-muted text-muted-foreground'
+						: null
 	);
+
+	const marks = (value: number) =>
+		`${value > 0 ? '+' : ''}${value} ${Math.abs(value) === 1 ? $t('mark') : $t('marks')}`;
 
 	const label = $derived(
 		result === 'correct'
-			? `${$t('Correct')}: +${scheme.correct} ${scheme.correct === 1 ? $t('mark') : $t('marks')}`
-			: result === 'incorrect'
-				? `${$t('Incorrect')}: ${scheme.wrong} ${Math.abs(scheme.wrong) === 1 ? $t('mark') : $t('marks')}`
-				: result === 'unattempted'
-					? `${$t('Not Attempted')}: ${scheme.skipped} ${scheme.skipped === 1 ? $t('mark') : $t('marks')}`
-					: null
+			? `${$t('Correct')}: ${marks(scheme.correct)}`
+			: result === 'partially-correct'
+				? // Fall back to the plain label when the caller did not say how many
+					// were correct, rather than showing marks that may be wrong.
+					partialMarks !== null
+					? `${$t('Partially Correct')}: ${marks(partialMarks)}`
+					: $t('Partially Correct')
+				: result === 'incorrect'
+					? `${$t('Incorrect')}: ${marks(scheme.wrong)}`
+					: result === 'unattempted'
+						? `${$t('Not Attempted')}: ${marks(scheme.skipped)}`
+						: null
 	);
 </script>
 

--- a/src/lib/components/ResultBadge.svelte
+++ b/src/lib/components/ResultBadge.svelte
@@ -29,7 +29,7 @@
 		result === 'correct'
 			? 'bg-success-subtle text-success'
 			: result === 'partially-correct'
-				? // Partial credit is still credit, so it reads as success -- the ring
+				? // Partial credit is still credit, so it reads as success — the ring
 					// and the label distinguish it from a fully correct answer. (Adding a
 					// fourth semantic colour would be a design decision; the palette
 					// currently defines only success, error and warning.)

--- a/src/lib/components/SectionBanner.svelte
+++ b/src/lib/components/SectionBanner.svelte
@@ -47,25 +47,23 @@
 		questions[0]?.question_type as question_type_enum | undefined
 	);
 
-	// Show the scheme where marks are meaningful. The question type is only
-	// needed to gate the partial-marks block, and the landing page's section
-	// summary carries no question list — so an unknown type still shows the
-	// scheme, it just cannot claim the set is multi-choice.
-	// A partial-marks ladder only exists on a multi-choice set, so its presence
-	// identifies the type when the payload does not carry one.
+	// The landing page's section summary carries no question list, so fall back
+	// to the scheme: a partial-marks ladder only exists on a multi-choice set,
+	// so its presence identifies the type.
 	const inferredQuestionType = $derived(
 		markingScheme?.partial?.correct_answers?.length
 			? ('multi-choice' as question_type_enum)
 			: undefined
 	);
 
-	// Only stated when the type is actually known -- the landing page's section
-	// summary may carry no question list, and guessing would be worse than
-	// silence.
+	// Null for an unknown type, so nothing is stated rather than something
+	// guessed.
 	const typeInstruction = $derived(
 		getQuestionTypeInstruction(sectionQuestionType ?? inferredQuestionType)
 	);
 
+	// Marks are only meaningful for gradable types. An unknown type still shows
+	// the scheme, since the landing page cannot tell what it is.
 	const canShowMarkingScheme = $derived(
 		showMarkingScheme &&
 			!!markingScheme &&

--- a/src/lib/components/SectionBanner.svelte
+++ b/src/lib/components/SectionBanner.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+	import MarkingSchemeContent from '$lib/components/MarkingSchemeContent.svelte';
+	import RichText from '$lib/components/RichText.svelte';
+	import { canAttemptAllQuestions } from '$lib/helpers/questionSetHelpers';
+	import { GRADABLE_QUESTION_TYPES } from '$lib/helpers/feedbackHelpers';
+	import type { TMarks, TQuestion, question_type_enum } from '$lib/types';
+	import { t } from 'svelte-i18n';
+
+	/**
+	 * The header shown above a section, on the landing page, above the questions
+	 * themselves, and in answer review.
+	 *
+	 * Previously this markup was repeated in each of those places, so a change to
+	 * one left the others behind and the marking scheme was shown in none of them.
+	 */
+	let {
+		title,
+		description = null,
+		maxQuestionsAllowedToAttempt,
+		questionCount,
+		questions = [],
+		markingScheme = null,
+		showMarkingScheme = false,
+		showQuestionCount = false,
+		class: className = '',
+		id = undefined
+	}: {
+		title: string;
+		description?: string | null;
+		maxQuestionsAllowedToAttempt: number;
+		questionCount: number;
+		questions?: TQuestion[];
+		markingScheme?: TMarks | null;
+		showMarkingScheme?: boolean;
+		showQuestionCount?: boolean;
+		class?: string;
+		id?: string;
+	} = $props();
+
+	const attemptsAll = $derived(canAttemptAllQuestions(maxQuestionsAllowedToAttempt, questionCount));
+
+	// MarkingSchemeContent renders type-specific wording (the partial-marks ladder
+	// only applies to multi-choice), so it needs a question type. A section is
+	// homogeneous by construction, so the first question represents the set.
+	const sectionQuestionType = $derived(
+		questions[0]?.question_type as question_type_enum | undefined
+	);
+
+	// Show the scheme where marks are meaningful. The question type is only
+	// needed to gate the partial-marks block, and the landing page's section
+	// summary carries no question list — so an unknown type still shows the
+	// scheme, it just cannot claim the set is multi-choice.
+	// A partial-marks ladder only exists on a multi-choice set, so its presence
+	// identifies the type when the payload does not carry one.
+	const inferredQuestionType = $derived(
+		markingScheme?.partial?.correct_answers?.length
+			? ('multi-choice' as question_type_enum)
+			: undefined
+	);
+
+	const canShowMarkingScheme = $derived(
+		showMarkingScheme &&
+			!!markingScheme &&
+			(!sectionQuestionType || GRADABLE_QUESTION_TYPES.has(sectionQuestionType))
+	);
+</script>
+
+<div {id} class={className}>
+	<div class="flex items-start justify-between gap-4">
+		<div>
+			<p class="text-card-foreground text-sm font-semibold">{title}</p>
+			{#if description}
+				<RichText content={description} class="text-muted-foreground mt-1 text-sm" />
+			{/if}
+		</div>
+		{#if showQuestionCount}
+			<p class="text-muted-foreground shrink-0 text-xs">
+				{questionCount}
+				{$t('questions')}
+			</p>
+		{/if}
+	</div>
+
+	<!-- Only state the attempt rule when it restricts the candidate. Saying "you
+	     may attempt all questions" adds a line without adding information. -->
+	{#if !attemptsAll}
+		<p class="text-muted-foreground mt-3 text-sm">
+			{$t('You may attempt up to {count} questions in this section.', {
+				values: { count: maxQuestionsAllowedToAttempt }
+			})}
+		</p>
+	{/if}
+
+	{#if canShowMarkingScheme && markingScheme}
+		<!-- MarkingSchemeContent is sized for the per-question popover, where it is
+		     the only thing on screen. In a section header it sits above the question
+		     it describes, so scale it down and cap the width to keep the question
+		     itself dominant. -->
+		<div class="mt-2 max-w-xs text-xs [&_*]:font-normal [&>div]:space-y-1">
+			<MarkingSchemeContent
+				scheme={markingScheme}
+				questionType={sectionQuestionType ?? inferredQuestionType}
+			/>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/SectionBanner.svelte
+++ b/src/lib/components/SectionBanner.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import MarkingSchemeContent from '$lib/components/MarkingSchemeContent.svelte';
+	import MarkingSchemeInline from '$lib/components/MarkingSchemeInline.svelte';
 	import RichText from '$lib/components/RichText.svelte';
 	import { canAttemptAllQuestions } from '$lib/helpers/questionSetHelpers';
 	import { GRADABLE_QUESTION_TYPES } from '$lib/helpers/feedbackHelpers';
@@ -39,7 +39,7 @@
 
 	const attemptsAll = $derived(canAttemptAllQuestions(maxQuestionsAllowedToAttempt, questionCount));
 
-	// MarkingSchemeContent renders type-specific wording (the partial-marks ladder
+	// The marking scheme's wording is type-specific (the partial-marks ladder
 	// only applies to multi-choice), so it needs a question type. A section is
 	// homogeneous by construction, so the first question represents the set.
 	const sectionQuestionType = $derived(
@@ -84,7 +84,7 @@
 	<!-- Only state the attempt rule when it restricts the candidate. Saying "you
 	     may attempt all questions" adds a line without adding information. -->
 	{#if !attemptsAll}
-		<p class="text-muted-foreground mt-3 text-sm">
+		<p class="text-muted-foreground mt-2 text-sm">
 			{$t('You may attempt up to {count} questions in this section.', {
 				values: { count: maxQuestionsAllowedToAttempt }
 			})}
@@ -92,15 +92,9 @@
 	{/if}
 
 	{#if canShowMarkingScheme && markingScheme}
-		<!-- MarkingSchemeContent is sized for the per-question popover, where it is
-		     the only thing on screen. In a section header it sits above the question
-		     it describes, so scale it down and cap the width to keep the question
-		     itself dominant. -->
-		<div class="mt-2 max-w-xs text-xs [&_*]:font-normal [&>div]:space-y-1">
-			<MarkingSchemeContent
-				scheme={markingScheme}
-				questionType={sectionQuestionType ?? inferredQuestionType}
-			/>
-		</div>
+		<MarkingSchemeInline
+			scheme={markingScheme}
+			questionType={sectionQuestionType ?? inferredQuestionType}
+		/>
 	{/if}
 </div>

--- a/src/lib/components/SectionBanner.svelte
+++ b/src/lib/components/SectionBanner.svelte
@@ -3,6 +3,7 @@
 	import RichText from '$lib/components/RichText.svelte';
 	import { canAttemptAllQuestions } from '$lib/helpers/questionSetHelpers';
 	import { GRADABLE_QUESTION_TYPES } from '$lib/helpers/feedbackHelpers';
+	import { getQuestionTypeInstruction } from '$lib/helpers/questionTypeLabels';
 	import type { TMarks, TQuestion, question_type_enum } from '$lib/types';
 	import { t } from 'svelte-i18n';
 
@@ -58,6 +59,13 @@
 			: undefined
 	);
 
+	// Only stated when the type is actually known -- the landing page's section
+	// summary may carry no question list, and guessing would be worse than
+	// silence.
+	const typeInstruction = $derived(
+		getQuestionTypeInstruction(sectionQuestionType ?? inferredQuestionType)
+	);
+
 	const canShowMarkingScheme = $derived(
 		showMarkingScheme &&
 			!!markingScheme &&
@@ -69,6 +77,9 @@
 	<div class="flex items-start justify-between gap-4">
 		<div>
 			<p class="text-card-foreground text-sm font-semibold">{title}</p>
+			{#if typeInstruction}
+				<p class="text-muted-foreground mt-0.5 text-xs">{$t(typeInstruction)}</p>
+			{/if}
 			{#if description}
 				<RichText content={description} class="text-muted-foreground mt-1 text-sm" />
 			{/if}

--- a/src/lib/components/SectionBanner.svelte
+++ b/src/lib/components/SectionBanner.svelte
@@ -8,11 +8,9 @@
 	import { t } from 'svelte-i18n';
 
 	/**
-	 * The header shown above a section, on the landing page, above the questions
-	 * themselves, and in answer review.
-	 *
-	 * Previously this markup was repeated in each of those places, so a change to
-	 * one left the others behind and the marking scheme was shown in none of them.
+	 * The header shown above a section — on the landing page, above the questions,
+	 * and in answer review. This markup was previously duplicated in each place,
+	 * so the marking scheme was shown in none of them.
 	 */
 	let {
 		title,
@@ -40,16 +38,13 @@
 
 	const attemptsAll = $derived(canAttemptAllQuestions(maxQuestionsAllowedToAttempt, questionCount));
 
-	// The marking scheme's wording is type-specific (the partial-marks ladder
-	// only applies to multi-choice), so it needs a question type. A section is
-	// homogeneous by construction, so the first question represents the set.
+	// A section is homogeneous, so the first question gives its type.
 	const sectionQuestionType = $derived(
 		questions[0]?.question_type as question_type_enum | undefined
 	);
 
-	// The landing page's section summary carries no question list, so fall back
-	// to the scheme: a partial-marks ladder only exists on a multi-choice set,
-	// so its presence identifies the type.
+	// The landing page carries no question list, so fall back to the scheme: a
+	// partial ladder only exists on a multi-choice set.
 	const inferredQuestionType = $derived(
 		markingScheme?.partial?.correct_answers?.length
 			? ('multi-choice' as question_type_enum)
@@ -62,8 +57,7 @@
 		getQuestionTypeInstruction(sectionQuestionType ?? inferredQuestionType)
 	);
 
-	// Marks are only meaningful for gradable types. An unknown type still shows
-	// the scheme, since the landing page cannot tell what it is.
+	// An unknown type still shows the scheme; the landing page cannot tell.
 	const canShowMarkingScheme = $derived(
 		showMarkingScheme &&
 			!!markingScheme &&
@@ -90,8 +84,8 @@
 		{/if}
 	</div>
 
-	<!-- Only state the attempt rule when it restricts the candidate. Saying "you
-	     may attempt all questions" adds a line without adding information. -->
+	<!-- Only stated when it restricts the candidate; "you may attempt all
+	     questions" is a line without information. -->
 	{#if !attemptsAll}
 		<p class="text-muted-foreground mt-2 text-sm">
 			{$t('You may attempt up to {count} questions in this section.', {

--- a/src/lib/components/TestResult.svelte
+++ b/src/lib/components/TestResult.svelte
@@ -6,7 +6,7 @@
 		getQuestionSetQuestionCount,
 		normalizeTestQuestions
 	} from '$lib/helpers/questionSetHelpers';
-	import { isNumericalAnswerCorrect } from '$lib/helpers/feedbackHelpers';
+	import { getQuestionResult } from '$lib/helpers/feedbackHelpers';
 	import { t } from 'svelte-i18n';
 	import type { TResultData, TFeedback, TTestQuestionsResponse } from '$lib/types';
 	import { CircleCheck, CircleX, CircleMinus } from '@lucide/svelte';
@@ -40,31 +40,18 @@
 	const feedbackByQuestionId = $derived(
 		new Map((feedback ?? []).map((entry) => [entry.question_revision_id, entry]))
 	);
-	const isFeedbackEntryCorrect = (
-		question: (typeof normalizedTestQuestions.questions)[number]
-	): boolean => {
+	/**
+	 * Classify a question's answer using the same helper the per-question badges
+	 * use, so the section tallies cannot drift from what the candidate is shown.
+	 */
+	const resultFor = (question: (typeof normalizedTestQuestions.questions)[number]) => {
 		const entry = feedbackByQuestionId.get(question.id);
-		if (!entry) return false;
-		if (typeof entry.correct_answer === 'number') {
-			if (typeof entry.submitted_answer !== 'string') {
-				return false;
-			}
-			return (
-				isNumericalAnswerCorrect(
-					question.question_type,
-					entry.submitted_answer,
-					entry.correct_answer
-				) === true
-			);
-		}
-		if (!Array.isArray(entry.submitted_answer) || !Array.isArray(entry.correct_answer)) {
-			return false;
-		}
-		const submittedAnswer = entry.submitted_answer;
-		const correctAnswer = entry.correct_answer;
-		return (
-			submittedAnswer.length === correctAnswer.length &&
-			submittedAnswer.every((answer) => correctAnswer.includes(answer))
+		if (!entry) return 'unattempted';
+		return getQuestionResult(
+			question.question_type,
+			entry.submitted_answer,
+			entry.correct_answer,
+			question.marking_scheme
 		);
 	};
 	const sectionSummaries = $derived(
@@ -80,17 +67,24 @@
 				}
 				return entry.submitted_answer.length > 0;
 			}).length;
-			const correctCount = group.questions.filter((question) =>
-				isFeedbackEntryCorrect(question)
-			).length;
+			const results = group.questions.map((question) => resultFor(question));
+			const correctCount = results.filter((r) => r === 'correct').length;
+			const partialCount = results.filter((r) => r === 'partially-correct').length;
 
 			return {
 				title: group.section.title,
 				questionCount: getQuestionSetQuestionCount(group.section),
 				attemptedCount,
 				correctCount,
+				partialCount,
 				allowedCount: group.section.max_questions_allowed_to_attempt,
-				accuracy: attemptedCount > 0 ? Math.round((correctCount / attemptedCount) * 100) : null
+				// Partial credit counts as credited (the backend tallies it under
+				// `correct`), so accuracy must include it or a section scored entirely
+				// on partial credit reads as 0%.
+				accuracy:
+					attemptedCount > 0
+						? Math.round(((correctCount + partialCount) / attemptedCount) * 100)
+						: null
 			};
 		})
 	);
@@ -245,7 +239,11 @@
 							</div>
 						</div>
 
-						<div class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3">
+						<div
+							class="mt-4 grid grid-cols-2 gap-3 {section.partialCount > 0
+								? 'sm:grid-cols-2'
+								: 'sm:grid-cols-3'}"
+						>
 							<div class="bg-muted rounded-xl p-3">
 								<p class="text-muted-foreground text-xs font-semibold uppercase">
 									{$t('Questions')}
@@ -258,12 +256,26 @@
 								</p>
 								<p class="text-foreground mt-1 text-xl font-semibold">{section.attemptedCount}</p>
 							</div>
-							<div class="bg-muted col-span-2 rounded-xl p-3 sm:col-span-1">
+							<div
+								class="bg-muted rounded-xl p-3 {section.partialCount > 0
+									? ''
+									: 'col-span-2 sm:col-span-1'}"
+							>
 								<p class="text-muted-foreground text-xs font-semibold uppercase">
 									{$t('Correct')}
 								</p>
 								<p class="text-foreground mt-1 text-xl font-semibold">{section.correctCount}</p>
 							</div>
+							<!-- Only shown where the section awards partial credit, so sections
+							     that cannot earn it are not given an always-zero tile. -->
+							{#if section.partialCount > 0}
+								<div class="bg-muted rounded-xl p-3">
+									<p class="text-muted-foreground text-xs font-semibold uppercase">
+										{$t('Partially Correct')}
+									</p>
+									<p class="text-foreground mt-1 text-xl font-semibold">{section.partialCount}</p>
+								</div>
+							{/if}
 						</div>
 					</div>
 				{/each}

--- a/src/lib/components/ViewFeedback.svelte
+++ b/src/lib/components/ViewFeedback.svelte
@@ -9,7 +9,11 @@
 	} from '$lib/helpers/questionSetHelpers';
 	import { t } from 'svelte-i18n';
 	import { question_type_enum, type TCandidate, type TSelection } from '$lib/types';
-	import { getQuestionResult, GRADABLE_QUESTION_TYPES } from '$lib/helpers/feedbackHelpers';
+	import {
+		getCorrectSelectedCount,
+		getQuestionResult,
+		GRADABLE_QUESTION_TYPES
+	} from '$lib/helpers/feedbackHelpers';
 	import RichText from './RichText.svelte';
 	import QuestionMedia from './QuestionMedia.svelte';
 	import ResultBadge from './ResultBadge.svelte';
@@ -88,9 +92,15 @@
 							result={getQuestionResult(
 								item.question.question_type,
 								item.fb.submitted_answer,
-								item.fb.correct_answer
+								item.fb.correct_answer,
+								item.question.marking_scheme
 							)}
 							scheme={item.question.marking_scheme}
+							correctSelected={getCorrectSelectedCount(
+								item.question.question_type,
+								item.fb.submitted_answer,
+								item.fb.correct_answer
+							)}
 						/>
 					{/if}
 				</Card.Title>
@@ -181,7 +191,7 @@
 					description={group.section.description}
 					maxQuestionsAllowedToAttempt={group.section.max_questions_allowed_to_attempt}
 					questionCount={group.questions.length}
-					class="mb-4 w-full max-w-sm rounded-2xl border bg-slate-50 p-4"
+					class="mb-3 w-full max-w-2xl rounded-xl border bg-slate-50 px-4 py-3 md:max-w-250"
 				/>
 				{#each group.questions as question, sectionIndex (question.id)}
 					{@const item = feedbackItemByQuestionId.get(question.id)}

--- a/src/lib/components/ViewFeedback.svelte
+++ b/src/lib/components/ViewFeedback.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import SectionBanner from './SectionBanner.svelte';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
 	import {
@@ -175,24 +176,13 @@
 		{/if}
 		{#if feedbackQuestionSetGroups.length > 0}
 			{#each feedbackQuestionSetGroups as group (`${group.section.id ?? group.section.title}-${group.startIndex}`)}
-				<div class="mb-4 w-full max-w-sm rounded-2xl border bg-slate-50 p-4">
-					<p class="text-sm font-semibold text-slate-800">{group.section.title}</p>
-					{#if group.section.description}
-						<RichText
-							content={group.section.description}
-							class="text-muted-foreground mt-1 text-sm"
-						/>
-					{/if}
-					<p class="text-muted-foreground mt-2 text-sm">
-						{#if canAttemptAllQuestions(group.section.max_questions_allowed_to_attempt, group.questions.length)}
-							{$t('You may attempt all questions in this section.')}
-						{:else}
-							{$t('You may attempt up to {count} questions in this section.', {
-								values: { count: group.section.max_questions_allowed_to_attempt }
-							})}
-						{/if}
-					</p>
-				</div>
+				<SectionBanner
+					title={group.section.title}
+					description={group.section.description}
+					maxQuestionsAllowedToAttempt={group.section.max_questions_allowed_to_attempt}
+					questionCount={group.questions.length}
+					class="mb-4 w-full max-w-sm rounded-2xl border bg-slate-50 p-4"
+				/>
 				{#each group.questions as question, sectionIndex (question.id)}
 					{@const item = feedbackItemByQuestionId.get(question.id)}
 					{#if item}

--- a/src/lib/helpers/feedbackHelpers.test.ts
+++ b/src/lib/helpers/feedbackHelpers.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
 	getQuestionResult,
+	getCorrectSelectedCount,
+	getPartialMarks,
 	parseMatrixAnswer,
 	getMatrixCellStatus,
 	normalizeFeedbackEntry
@@ -322,5 +324,82 @@ describe('normalizeFeedbackEntry', () => {
 				correct_answer: []
 			}).submitted_answer
 		).toBe('42');
+	});
+});
+
+describe('partial credit', () => {
+	// The JEE Advanced shape: all four correct earns +4, any wrong option loses
+	// 2, and picking only correct options earns a rung of the ladder.
+	const ladderScheme = {
+		correct: 4,
+		wrong: -2,
+		skipped: 0,
+		partial: {
+			correct_answers: [
+				{ num_correct_selected: 1, marks: 1 },
+				{ num_correct_selected: 2, marks: 2 },
+				{ num_correct_selected: 3, marks: 3 }
+			]
+		}
+	};
+
+	it('reports partially correct when only some correct options are selected', () => {
+		expect(getQuestionResult(question_type_enum.MULTIPLE, [1], [1, 2], ladderScheme)).toBe(
+			'partially-correct'
+		);
+	});
+
+	it('still reports correct when every correct option is selected', () => {
+		expect(getQuestionResult(question_type_enum.MULTIPLE, [1, 2], [1, 2], ladderScheme)).toBe(
+			'correct'
+		);
+	});
+
+	it('reports incorrect when a wrong option is also selected', () => {
+		// Partial credit requires that nothing wrong was picked, so this scores
+		// the full negative mark rather than a rung of the ladder.
+		expect(getQuestionResult(question_type_enum.MULTIPLE, [1, 3], [1, 2], ladderScheme)).toBe(
+			'incorrect'
+		);
+	});
+
+	it('reports incorrect without a scheme, since partial credit cannot be known', () => {
+		expect(getQuestionResult(question_type_enum.MULTIPLE, [1], [1, 2])).toBe('incorrect');
+	});
+
+	it('reports incorrect when the scheme has no rung for that many correct', () => {
+		const sparse = {
+			correct: 4,
+			wrong: -2,
+			skipped: 0,
+			partial: { correct_answers: [{ num_correct_selected: 3, marks: 3 }] }
+		};
+		expect(getQuestionResult(question_type_enum.MULTIPLE, [1], [1, 2, 3, 4], sparse)).toBe(
+			'incorrect'
+		);
+	});
+
+	it('does not award partial credit to a single-choice answer', () => {
+		expect(getQuestionResult(question_type_enum.SINGLE, [2], [1], ladderScheme)).toBe('incorrect');
+	});
+
+	it('looks up the marks for the number of correct selections', () => {
+		expect(getPartialMarks(ladderScheme, 2)).toBe(2);
+		expect(getPartialMarks(ladderScheme, 4)).toBeNull();
+		expect(getPartialMarks({ correct: 4, wrong: -1, skipped: 0 }, 1)).toBeNull();
+	});
+
+	it('counts the correct selections behind a partial award', () => {
+		expect(getCorrectSelectedCount(question_type_enum.MULTIPLE, [1, 3], [1, 2, 3])).toBe(2);
+	});
+
+	it('counts fully matched rows for matrix-match', () => {
+		// Matrix-match scores per row, so its ladder is keyed on matched rows.
+		const submitted = JSON.stringify({ '1': [10], '2': [99] });
+		const correct = JSON.stringify({ '1': [10], '2': [20] });
+		expect(getCorrectSelectedCount(question_type_enum.MATRIXMATCH, submitted, correct)).toBe(1);
+		expect(
+			getQuestionResult(question_type_enum.MATRIXMATCH, submitted, correct, ladderScheme)
+		).toBe('partially-correct');
 	});
 });

--- a/src/lib/helpers/feedbackHelpers.ts
+++ b/src/lib/helpers/feedbackHelpers.ts
@@ -1,4 +1,4 @@
-import { question_type_enum } from '$lib/types';
+import { question_type_enum, type TMarks } from '$lib/types';
 
 export const GRADABLE_QUESTION_TYPES = new Set([
 	question_type_enum.SINGLE,
@@ -93,11 +93,60 @@ export const isNumericalAnswerCorrect = (
 	return null;
 };
 
+export type TQuestionResult = 'correct' | 'partially-correct' | 'incorrect' | 'unattempted';
+
+/**
+ * How many of the correct answers the candidate picked, and whether they also
+ * picked anything wrong.
+ *
+ * Partial credit only applies when nothing wrong was selected -- see the
+ * scoring rule in the backend's submit_test.
+ */
+const countCorrectSelected = (
+	submitted: number[],
+	correctAnswer: number[]
+): { correctSelected: number; hasWrong: boolean } => {
+	const correctSet = new Set(correctAnswer);
+	let correctSelected = 0;
+	let hasWrong = false;
+	for (const id of new Set(submitted)) {
+		if (correctSet.has(id)) correctSelected++;
+		else hasWrong = true;
+	}
+	return { correctSelected, hasWrong };
+};
+
+/**
+ * The marks a partially correct answer earns, or null when the scheme awards
+ * none for that many correct selections.
+ *
+ * The backend looks for the rung matching the exact count and awards 0 when
+ * there is none, so an unmatched count is not the same as a wrong answer.
+ */
+export const getPartialMarks = (
+	scheme: TMarks | null | undefined,
+	correctSelected: number
+): number | null => {
+	const rungs = scheme?.partial?.correct_answers;
+	if (!rungs?.length) return null;
+	const rung = rungs.find((r) => r.num_correct_selected === correctSelected);
+	return rung ? rung.marks : null;
+};
+
+/**
+ * Classify an answer for display.
+ *
+ * `scheme` is optional: without it a partially correct answer cannot be
+ * distinguished from a wrong one, so callers that show marks should pass it.
+ * Note the backend counts a partially correct answer in its `correct` tally,
+ * so summaries must treat 'partially-correct' as attempted-and-credited.
+ */
 export const getQuestionResult = (
 	questionType: question_type_enum,
 	submitted: number[] | string | null | undefined,
-	correctAnswer: number[] | number | null | undefined
-): 'correct' | 'incorrect' | 'unattempted' => {
+	correctAnswer: number[] | number | null | undefined,
+	scheme?: TMarks | null
+): TQuestionResult => {
 	if (
 		questionType === question_type_enum.NUMERICALINTEGER ||
 		questionType === question_type_enum.NUMERICALDECIMAL
@@ -118,13 +167,10 @@ export const getQuestionResult = (
 	if (questionType === question_type_enum.SINGLE || questionType === question_type_enum.MULTIPLE) {
 		if (!Array.isArray(submitted) || submitted.length === 0) return 'unattempted';
 		if (!Array.isArray(correctAnswer) || correctAnswer.length === 0) return 'unattempted';
-		const correctSet = new Set(correctAnswer);
-		const submittedSet = new Set(submitted);
-		if (
-			submittedSet.size === correctSet.size &&
-			[...submittedSet].every((id) => correctSet.has(id))
-		) {
-			return 'correct';
+		const { correctSelected, hasWrong } = countCorrectSelected(submitted, correctAnswer);
+		if (!hasWrong && correctSelected === correctAnswer.length) return 'correct';
+		if (!hasWrong && correctSelected > 0 && getPartialMarks(scheme, correctSelected) !== null) {
+			return 'partially-correct';
 		}
 		return 'incorrect';
 	}
@@ -134,16 +180,48 @@ export const getQuestionResult = (
 		const cor = parseMatrixAnswer(correctAnswer as string);
 		if (Object.keys(cor).length === 0) return 'unattempted';
 		if (Object.keys(sub).length === 0) return 'unattempted';
-		const allCorrect = Object.entries(cor).every(([rowId, correctCols]) => {
+		const rows = Object.entries(cor);
+		const matchedRows = rows.filter(([rowId, correctCols]) => {
 			const submittedCols = sub[rowId] ?? [];
 			return (
 				correctCols.length === submittedCols.length &&
 				correctCols.every((id) => submittedCols.includes(id))
 			);
-		});
-		if (allCorrect) return 'correct';
+		}).length;
+		if (matchedRows === rows.length) return 'correct';
+		// Matrix-match scores per fully-matched row, so its partial ladder is
+		// keyed on the number of matched rows rather than selected options.
+		if (matchedRows > 0 && getPartialMarks(scheme, matchedRows) !== null) {
+			return 'partially-correct';
+		}
 		return 'incorrect';
 	}
 
 	return 'unattempted';
+};
+
+/**
+ * How many correct answers were selected, for reporting partial marks.
+ *
+ * Matrix-match counts fully-matched rows; the option-based types count correct
+ * options. Returns null when the answer type carries no such count.
+ */
+export const getCorrectSelectedCount = (
+	questionType: question_type_enum,
+	submitted: number[] | string | null | undefined,
+	correctAnswer: number[] | number | null | undefined
+): number | null => {
+	if (questionType === question_type_enum.MATRIXMATCH) {
+		const sub = parseMatrixAnswer(submitted as string);
+		const cor = parseMatrixAnswer(correctAnswer as string);
+		return Object.entries(cor).filter(([rowId, correctCols]) => {
+			const submittedCols = sub[rowId] ?? [];
+			return (
+				correctCols.length === submittedCols.length &&
+				correctCols.every((id) => submittedCols.includes(id))
+			);
+		}).length;
+	}
+	if (!Array.isArray(submitted) || !Array.isArray(correctAnswer)) return null;
+	return countCorrectSelected(submitted, correctAnswer).correctSelected;
 };

--- a/src/lib/helpers/feedbackHelpers.ts
+++ b/src/lib/helpers/feedbackHelpers.ts
@@ -99,7 +99,7 @@ export type TQuestionResult = 'correct' | 'partially-correct' | 'incorrect' | 'u
  * How many of the correct answers the candidate picked, and whether they also
  * picked anything wrong.
  *
- * Partial credit only applies when nothing wrong was selected -- see the
+ * Partial credit only applies when nothing wrong was selected — see the
  * scoring rule in the backend's submit_test.
  */
 const countCorrectSelected = (

--- a/src/lib/helpers/questionTypeLabels.ts
+++ b/src/lib/helpers/questionTypeLabels.ts
@@ -1,16 +1,12 @@
 import { question_type_enum } from '$lib/types';
 
 /**
- * What a question type asks of the candidate, in one short phrase.
+ * What a question type asks of the candidate, so a section header can state it
+ * once instead of an importer writing the same sentence into every section's
+ * description by hand.
  *
- * Sections are homogeneous, so a section header can state this once instead of
- * repeating it on every question. Deriving it from the type means an importer
- * does not have to ship the same sentence as prose in the section description
- * (and cannot word it inconsistently between sections).
- *
- * Keep these phrasings answer-shape only — how many options to pick, what kind
- * of value to enter. Marks belong to the marking scheme, which is rendered
- * separately, and anything exam-specific belongs in the section description.
+ * Answer shape only — marks come from the marking scheme, and anything
+ * exam-specific belongs in the section description.
  */
 const QUESTION_TYPE_INSTRUCTIONS: Record<question_type_enum, string> = {
 	[question_type_enum.SINGLE]: 'Choose ONE correct option',
@@ -23,15 +19,7 @@ const QUESTION_TYPE_INSTRUCTIONS: Record<question_type_enum, string> = {
 	[question_type_enum.MATRIXINPUT]: 'Enter a value for each row'
 };
 
-/**
- * The instruction for a question type, or null for an unknown one.
- *
- * Returns null rather than a fallback so a type added to the backend without a
- * phrasing here shows nothing instead of something misleading.
- */
+/** Null for an unknown type, so nothing is shown rather than a wrong guess. */
 export const getQuestionTypeInstruction = (
 	questionType: question_type_enum | null | undefined
-): string | null => {
-	if (!questionType) return null;
-	return QUESTION_TYPE_INSTRUCTIONS[questionType] ?? null;
-};
+): string | null => (questionType ? (QUESTION_TYPE_INSTRUCTIONS[questionType] ?? null) : null);

--- a/src/lib/helpers/questionTypeLabels.ts
+++ b/src/lib/helpers/questionTypeLabels.ts
@@ -1,0 +1,37 @@
+import { question_type_enum } from '$lib/types';
+
+/**
+ * What a question type asks of the candidate, in one short phrase.
+ *
+ * Sections are homogeneous, so a section header can state this once instead of
+ * repeating it on every question. Deriving it from the type means an importer
+ * does not have to ship the same sentence as prose in the section description
+ * (and cannot word it inconsistently between sections).
+ *
+ * Keep these phrasings answer-shape only -- how many options to pick, what kind
+ * of value to enter. Marks belong to the marking scheme, which is rendered
+ * separately, and anything exam-specific belongs in the section description.
+ */
+const QUESTION_TYPE_INSTRUCTIONS: Record<question_type_enum, string> = {
+	[question_type_enum.SINGLE]: 'Choose ONE correct option',
+	[question_type_enum.MULTIPLE]: 'Choose ONE or MORE correct options',
+	[question_type_enum.NUMERICALINTEGER]: 'Enter an integer answer',
+	[question_type_enum.NUMERICALDECIMAL]: 'Enter a numerical answer',
+	[question_type_enum.SUBJECTIVE]: 'Write your answer',
+	[question_type_enum.MATRIXMATCH]: 'Match each row to its column',
+	[question_type_enum.MATRIXRATING]: 'Rate each row',
+	[question_type_enum.MATRIXINPUT]: 'Enter a value for each row'
+};
+
+/**
+ * The instruction for a question type, or null for an unknown one.
+ *
+ * Returns null rather than a fallback so a type added to the backend without a
+ * phrasing here shows nothing instead of something misleading.
+ */
+export const getQuestionTypeInstruction = (
+	questionType: question_type_enum | null | undefined
+): string | null => {
+	if (!questionType) return null;
+	return QUESTION_TYPE_INSTRUCTIONS[questionType] ?? null;
+};

--- a/src/lib/helpers/questionTypeLabels.ts
+++ b/src/lib/helpers/questionTypeLabels.ts
@@ -8,7 +8,7 @@ import { question_type_enum } from '$lib/types';
  * does not have to ship the same sentence as prose in the section description
  * (and cannot word it inconsistently between sections).
  *
- * Keep these phrasings answer-shape only -- how many options to pick, what kind
+ * Keep these phrasings answer-shape only — how many options to pick, what kind
  * of value to enter. Marks belong to the marking scheme, which is rendered
  * separately, and anything exam-specific belongs in the section description.
  */

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -69,7 +69,6 @@
 	"Go to question {number}": "Go to question {number}",
 	"Question Palette": "Question Palette",
 	"Sections": "Sections",
-	"Questions": "Questions",
 	"Attempted": "Attempted",
 	"Allowed": "Allowed",
 	"Accuracy": "Accuracy",
@@ -141,5 +140,16 @@
 	"Up to {max} characters": "Up to {max} characters",
 	"At least {min} character": "At least {min} character",
 	"At least {min} characters": "At least {min} characters",
-	"Open date picker": "Open date picker"
+	"Open date picker": "Open date picker",
+	"Partially Correct": "Partially Correct",
+	"Partial": "Partial",
+	"if no wrong option is selected": "if no wrong option is selected",
+	"Choose ONE correct option": "Choose ONE correct option",
+	"Choose ONE or MORE correct options": "Choose ONE or MORE correct options",
+	"Enter an integer answer": "Enter an integer answer",
+	"Enter a numerical answer": "Enter a numerical answer",
+	"Write your answer": "Write your answer",
+	"Match each row to its column": "Match each row to its column",
+	"Rate each row": "Rate each row",
+	"Enter a value for each row": "Enter a value for each row"
 }

--- a/src/locales/hi-IN.json
+++ b/src/locales/hi-IN.json
@@ -62,7 +62,6 @@
 	"Go to question {number}": "प्रश्न {number} पर जाएं",
 	"Question Palette": "प्रश्न पैलेट",
 	"Sections": "सेक्शन",
-	"Questions": "प्रश्न",
 	"Attempted": "प्रयास किया",
 	"Allowed": "अनुमत",
 	"Accuracy": "सटीकता",
@@ -143,5 +142,16 @@
 	"Up to {max} characters": "अधिकतम {max} अक्षर",
 	"At least {min} character": "कम से कम {min} अक्षर",
 	"At least {min} characters": "कम से कम {min} अक्षर",
-	"Open date picker": "दिनांक चुनें"
+	"Open date picker": "दिनांक चुनें",
+	"Partially Correct": "आंशिक रूप से सही",
+	"Partial": "आंशिक",
+	"if no wrong option is selected": "यदि कोई गलत विकल्प चयनित नहीं है",
+	"Choose ONE correct option": "एक सही विकल्प चुनें",
+	"Choose ONE or MORE correct options": "एक या अधिक सही विकल्प चुनें",
+	"Enter an integer answer": "पूर्णांक उत्तर दर्ज करें",
+	"Enter a numerical answer": "संख्यात्मक उत्तर दर्ज करें",
+	"Write your answer": "अपना उत्तर लिखें",
+	"Match each row to its column": "प्रत्येक पंक्ति को उसके स्तंभ से मिलाएँ",
+	"Rate each row": "प्रत्येक पंक्ति को रेट करें",
+	"Enter a value for each row": "प्रत्येक पंक्ति के लिए मान दर्ज करें"
 }


### PR DESCRIPTION
Renders the section banner from the section's own data, in the format agreed on sashakt-core#583: title, description, marking scheme, attempt cap.

Until now the marking scheme was only visible if an importer wrote it into `description` as pre-styled HTML — so it was unreadable in the UI unless someone sent prose for it, and an admin could not edit that prose. The banner markup was also copy-pasted in seven places across five components, and the scheme appeared in none of them.

Fixes sashakt-platform/sashakt-core#583.

### What changed

- New `SectionBanner`, replacing the seven duplicated copies (landing page, question screen, answer review, palette).
- New `MarkingSchemeInline` — a one-line scheme for headers. `MarkingSchemeContent` is a stacked list sized for the per-question popover; in a full-width header `justify-between` pushes each value far from its label and a partial ladder becomes eight lines.
- Dropped the "You may attempt all questions in this section" line. It only carries information when the section is capped, so it is now shown only then.

### Also fixes three pre-existing bugs

These are separate from #583 and each has its own issue.

**#282 — Answer Review reported the wrong marks for a partially correct answer.** `getQuestionResult` only knew correct/incorrect/unattempted, so a partial answer was classed incorrect and the badge printed the scheme's wrong mark: a candidate awarded **+1** was told they had lost **2 marks**. Adds a `partially-correct` state that follows the backend's rule in `submit_test` — partial credit only when no wrong option is selected, an unmatched rung awards 0 rather than the wrong mark, and `matrix-match` earns it per fully-matched row.

**#283 — Section summary did not count partially correct answers.** `TestResult` recomputed correctness with a near-duplicate of that helper, so a section scored entirely on partial credit read `Correct 0` / `Accuracy 0%` while the score box above it said otherwise. It now uses the shared helper and shows a Partially Correct count, so the two cannot drift again. (The backend counts partial answers under `correct`, so accuracy includes them.) Deleting the duplicate also removed a latent bug: it compared selections with an equal-length check plus `includes`, so a duplicated selection could pass.

**#284 — the fixed Start Test bar covered the last section card,** with no bottom padding reserving its height, so on a test with an odd number of sections the final card could not be scrolled into view.

### One thing to confirm

The banner shows the answer shape derived from the question type — "Choose ONE correct option" / "Choose ONE or MORE correct options" (`questionTypeLabels.ts`).

This is the "Type of questions in Question Set" line that was struck out in #583. I have included it because it is the other half of what importers were writing into `description` by hand, and deriving it means two sections cannot word the same thing differently. Happy to drop it if you would rather keep it out — it is one `{#if}` in `SectionBanner` and one file.

Unknown types render nothing rather than a fallback, so a type added to the backend without a phrasing here degrades quietly.

### Notes for review

- Marking scheme is shown on the landing page and question screen, and deliberately **not** in Answer Review, which already shows the actual marks earned per question.
- All new user-facing strings are in `en-US` and `hi-IN`. Two strings from an earlier commit on this branch were missing from both, which would have rendered raw keys in Hindi; added.
- The partial badge reuses the existing `success` tokens with a ring rather than introducing a fourth semantic colour. The palette defines only success/error/warning and `warning` already means "skipped", so a new colour felt like a design call rather than a bug fix. Quiz Engine uses blue for this — say the word and I will add the token.

### Testing

1195 unit tests pass (+9 covering partial credit: no scheme, sparse ladder, single-choice, matrix-match).

Walked end to end in the browser on a JEE Advanced-shaped test (`+4` / `-2` / `+1,+2,+3`):

- Landing page shows each section's own scheme side by side, Chemistry's ladder next to Physics without one.
- The banner switches correctly at the section boundary and the ladder disappears for single-correct.
- Answering 1 of 2 correct, then 2 of 3 correct, then one full-correct scored **7/20** = `+1 + 2 + 4`, matching the backend exactly.
- Answer Review shows "Partially Correct: +1 mark" where it previously said "Incorrect: -2 marks".

`npx svelte-check` currently crashes on this repo (`useCaseSensitiveFileNames`, a svelte-check/TypeScript 7 incompatibility) on `main` as well as here, so type checking was not run. Worth its own issue.

Prettier reports four files as unformatted — `MarkingSchemeContent`, `PreTestTimer`, `SubjectiveAnswer`, `DynamicForm` — all untouched by this branch, pre-existing on `main`. Left alone to keep the diff reviewable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent section banners with descriptions, question counts, attempt limits, instructions, and marking schemes.
  * Added support for partial-credit scoring in question feedback and result summaries.
  * Partial results now show correctly selected answers and earned marks.
  * Added guidance for supported question types, including matrix and multiple-choice questions.

* **Bug Fixes**
  * Removed misleading “attempt all questions” messages from unrestricted sections.
  * Improved accuracy calculations to include partial-credit responses.

* **Localization**
  * Added Hindi and English translations for new instructions and partial-credit labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->